### PR TITLE
Fix for UNDERTOW-917

### DIFF
--- a/src/main/java/org/apache/jasper/servlet/JspServlet.java
+++ b/src/main/java/org/apache/jasper/servlet/JspServlet.java
@@ -294,6 +294,7 @@ public class JspServlet extends HttpServlet implements PeriodicEventListener, Re
             // against verb tampering
             response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED,
                     MESSAGES.forbiddenHttpMethod());
+            return;
         }
 
         String jspFileAttr = (String) request.getAttribute(Constants.JSP_FILE);

--- a/src/test/java/io/undertow/test/jsp/basic/200.jsp
+++ b/src/test/java/io/undertow/test/jsp/basic/200.jsp
@@ -1,0 +1,3 @@
+<%
+    response.setStatus(200);
+%>


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/UNDERTOW-917. As noted in that JIRA, IMO, the original code was missing a `return` statement in the `if` block where the incoming HTTP method was being checked.

This commit also adds a test case to verify the change.
