### PR TITLE
Tests for referencing class from jsp

### DIFF
--- a/src/test/java/io/undertow/test/jsp/classref/ClassRefTestCase.java
+++ b/src/test/java/io/undertow/test/jsp/classref/ClassRefTestCase.java
@@ -1,0 +1,85 @@
+package io.undertow.test.jsp.classref;
+
+import io.undertow.jsp.HackInstanceManager;
+import io.undertow.jsp.JspServletBuilder;
+import io.undertow.server.handlers.PathHandler;
+import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.DeploymentManager;
+import io.undertow.servlet.api.ServletContainer;
+import io.undertow.servlet.test.util.TestClassIntrospector;
+import io.undertow.servlet.test.util.TestResourceLoader;
+import io.undertow.testutils.DefaultServer;
+import io.undertow.testutils.TestHttpClient;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.jasper.deploy.JspPropertyGroup;
+import org.apache.jasper.deploy.TagLibraryInfo;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.HashMap;
+import javax.servlet.ServletException;
+
+/**
+ * @tpChapter Class access from jsp
+ */
+
+@RunWith(DefaultServer.class)
+public class ClassRefTestCase {
+    private static final String CONTEXT_NAME = "classref";
+    private static final String CONTEXT_PATH = "/" + CONTEXT_NAME;
+
+    @BeforeClass
+    public static void setup() throws ServletException {
+
+        final PathHandler servletPath = new PathHandler();
+        final ServletContainer container = ServletContainer.Factory.newInstance();
+
+        DeploymentInfo builder = new DeploymentInfo()
+                .setClassLoader(ClassRefTestCase.class.getClassLoader())
+                .setContextPath(CONTEXT_PATH)
+                .setClassIntrospecter(TestClassIntrospector.INSTANCE)
+                .setDeploymentName(CONTEXT_NAME + ".war")
+                .setResourceManager(new TestResourceLoader(ClassRefTestCase.class))
+                .addServlet(JspServletBuilder.createServlet("Default Jsp Servlet", "*.jsp"));
+
+        JspServletBuilder.setupDeployment(builder, new HashMap<String, JspPropertyGroup>(),
+                new HashMap<String, TagLibraryInfo>(), new HackInstanceManager());
+
+        DeploymentManager manager = container.addDeployment(builder);
+        manager.deploy();
+        servletPath.addPrefixPath(builder.getContextPath(), manager.start());
+
+        DefaultServer.setRootHandler(servletPath);
+    }
+
+    /**
+     * @tpTestDetails Having class with the same name as package name with exception of case can be correctly accessed from JSP
+     * for cases when the class is called directly, via FQDN and also indirectly via other class
+     */
+    @Test
+    public void testDirectClassCallFromJsp() throws IOException {
+        Assert.assertEquals("Direct access of class from jsp page for class with name matching package name "
+                        + "with exception of case should succeed",
+                HttpURLConnection.HTTP_OK, statusCodeForResource("test_direct.jsp"));
+        Assert.assertEquals("Access via FQDN to class from jsp page for class with name matching package name "
+                        + "with exception of case should succeed",
+                HttpURLConnection.HTTP_OK, statusCodeForResource("test_fqdn.jsp"));
+        Assert.assertEquals("Access indirectly via different class to class from jsp page for class with name matching "
+                        + "package name with exception of case should succeed",
+                HttpURLConnection.HTTP_OK, statusCodeForResource("test_indirect.jsp"));
+    }
+
+    private int statusCodeForResource(String resourceName) throws IOException {
+        try (TestHttpClient client = new TestHttpClient()) {
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL() + CONTEXT_PATH + "/" + resourceName);
+            HttpResponse result = client.execute(get);
+            return result.getStatusLine().getStatusCode();
+        }
+    }
+
+}

--- a/src/test/java/io/undertow/test/jsp/classref/Indirect.java
+++ b/src/test/java/io/undertow/test/jsp/classref/Indirect.java
@@ -1,0 +1,10 @@
+package io.undertow.test.jsp.classref;
+
+import io.undertow.test.jsp.classref.testname.MyTest;
+
+public class Indirect {
+
+    public Indirect() {
+        MyTest myTest = new MyTest();
+    }
+}

--- a/src/test/java/io/undertow/test/jsp/classref/TestName.java
+++ b/src/test/java/io/undertow/test/jsp/classref/TestName.java
@@ -1,0 +1,4 @@
+package io.undertow.test.jsp.classref;
+
+public class TestName {
+}

--- a/src/test/java/io/undertow/test/jsp/classref/test_direct.jsp
+++ b/src/test/java/io/undertow/test/jsp/classref/test_direct.jsp
@@ -1,0 +1,7 @@
+<%@ page import="io.undertow.test.jsp.classref.testname.MyTest"%>
+
+<%
+	MyTest test = new MyTest();
+%>
+
+Direct MyTest class access

--- a/src/test/java/io/undertow/test/jsp/classref/test_fqdn.jsp
+++ b/src/test/java/io/undertow/test/jsp/classref/test_fqdn.jsp
@@ -1,0 +1,5 @@
+<%
+	io.undertow.test.jsp.classref.testname.MyTest test = new io.undertow.test.jsp.classref.testname.MyTest();
+%>
+
+FQDN access of MyTest class

--- a/src/test/java/io/undertow/test/jsp/classref/test_indirect.jsp
+++ b/src/test/java/io/undertow/test/jsp/classref/test_indirect.jsp
@@ -1,0 +1,7 @@
+<%@ page import="io.undertow.test.jsp.classref.Indirect"%>
+
+<%
+	Indirect indirect = new Indirect();
+%>
+
+Indirect access to MyTest class via Indirect class

--- a/src/test/java/io/undertow/test/jsp/classref/testname/MyTest.java
+++ b/src/test/java/io/undertow/test/jsp/classref/testname/MyTest.java
@@ -1,0 +1,4 @@
+package io.undertow.test.jsp.classref.testname;
+
+public class MyTest {
+}


### PR DESCRIPTION
The class name and package name are the same with exception of the case
and it is expected that it will properly initialize expected class and
it will not result in conflict with package name, not even on systems as
is Windows which is in many cases case insensitive.

=> test for https://issues.jboss.org/browse/JBEAP-13828