### PR TITLE
[WFLY-6263][JBEAP-13924][JBEAP-13925][JBEAP-13897] Apostrophe in an a…

### DIFF
--- a/src/main/java/org/apache/jasper/compiler/ELParser.java
+++ b/src/main/java/org/apache/jasper/compiler/ELParser.java
@@ -107,11 +107,17 @@ public class ELParser {
         ELexpr = new ELNode.Nodes();
         curToken = null;
         prevToken = null;
+        int openBraces = 0;
         while (hasNext()) {
             curToken = nextToken();
             if (curToken instanceof Char) {
-                if (curToken.toChar() == '}' && (index == expression.lastIndexOf('}') + 1)) {
-                    break;
+                if (curToken.toChar() == '}') {
+                    openBraces--;
+                    if (openBraces < 0) {
+                        break;
+                    }
+                } else if (curToken.toChar() == '{') {
+                    openBraces++;
                 }
                 buf.append(curToken.toString());
             } else {

--- a/test/org/apache/el/TestELInJsp.java
+++ b/test/org/apache/el/TestELInJsp.java
@@ -1,0 +1,527 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.el;
+
+import java.io.File;
+import java.math.RoundingMode;
+import java.util.Collections;
+
+import javax.servlet.DispatcherType;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.apache.catalina.Wrapper;
+import org.apache.catalina.core.StandardContext;
+import org.apache.catalina.startup.Tomcat;
+import org.apache.catalina.startup.TomcatBaseTest;
+import org.apache.jasper.servlet.JasperInitializer;
+import org.apache.tomcat.util.buf.ByteChunk;
+
+/**
+ * Tests EL with an without JSP attributes using a test web application. Similar
+ * tests may be found in {@link TestELEvaluation} and
+ * {@link org.apache.jasper.compiler.TestAttributeParser}.
+ */
+public class TestELInJsp extends TomcatBaseTest {
+
+    @Test
+    public void testBug36923() throws Exception {
+        getTomcatInstanceTestWebapp(false, true);
+
+        ByteChunk res = getUrl("http://localhost:" + getPort() + "/test/bug36923.jsp");
+
+        String result = res.toString();
+        assertEcho(result, "00-${hello world}");
+    }
+
+    @Test
+    public void testBug42565() throws Exception {
+        getTomcatInstanceTestWebapp(false, true);
+
+        ByteChunk res = getUrl("http://localhost:" + getPort() + "/test/bug42565.jsp");
+
+        String result = res.toString();
+        assertEcho(result, "00-false");
+        assertEcho(result, "01-false");
+        assertEcho(result, "02-false");
+        assertEcho(result, "03-false");
+        assertEcho(result, "04-false");
+        assertEcho(result, "05-false");
+        assertEcho(result, "06-false");
+        assertEcho(result, "07-false");
+        assertEcho(result, "08-false");
+        assertEcho(result, "09-false");
+        assertEcho(result, "10-false");
+        assertEcho(result, "11-false");
+        assertEcho(result, "12-false");
+        assertEcho(result, "13-false");
+        assertEcho(result, "14-false");
+        assertEcho(result, "15-false");
+    }
+
+    @Test
+    public void testBug44994() throws Exception {
+        getTomcatInstanceTestWebapp(false, true);
+
+        ByteChunk res = getUrl("http://localhost:" + getPort() + "/test/bug44994.jsp");
+
+        String result = res.toString();
+        assertEcho(result, "00-none");
+        assertEcho(result, "01-one");
+        assertEcho(result, "02-many");
+    }
+
+    @Test
+    public void testBug45427() throws Exception {
+        getTomcatInstanceTestWebapp(false, true);
+
+        ByteChunk res = getUrl("http://localhost:" + getPort() +
+                "/test/bug45nnn/bug45427.jsp");
+
+        String result = res.toString();
+        // Warning: JSP attribute escaping != Java String escaping
+        assertEcho(result, "00-hello world");
+        assertEcho(result, "01-hello 'world");
+        assertEcho(result, "02-hello \"world");
+        assertEcho(result, "03-hello \"world");
+        assertEcho(result, "04-hello world");
+        assertEcho(result, "05-hello 'world");
+        assertEcho(result, "06-hello 'world");
+        assertEcho(result, "07-hello \"world");
+        assertEcho(result, "08-hello world");
+        assertEcho(result, "09-hello 'world");
+        assertEcho(result, "10-hello \"world");
+        assertEcho(result, "11-hello \"world");
+        assertEcho(result, "12-hello world");
+        assertEcho(result, "13-hello 'world");
+        assertEcho(result, "14-hello 'world");
+        assertEcho(result, "15-hello \"world");
+    }
+
+    @Test
+    public void testBug45451() throws Exception {
+        getTomcatInstanceTestWebapp(false, true);
+
+        ByteChunk res = getUrl("http://localhost:" + getPort() +
+                "/test/bug45nnn/bug45451a.jsp");
+
+        String result = res.toString();
+        // Warning: JSP attribute escaping != Java String escaping
+        assertEcho(result, "00-\\'hello world\\'");
+        assertEcho(result, "01-\\'hello world\\'");
+        assertEcho(result, "02-\\'hello world\\'");
+        assertEcho(result, "03-\\'hello world\\'");
+
+        res = getUrl("http://localhost:" + getPort() + "/test/bug45nnn/bug45451b.jsp");
+        result = res.toString();
+        // Warning: JSP attribute escaping != Java String escaping
+        // Warning: Attributes are always unescaped before passing to the EL
+        //          processor
+        assertEcho(result, "00-2");
+        assertEcho(result, "01-${1+1}");
+        assertEcho(result, "02-\\${1+1}");
+        assertEcho(result, "03-\\\\${1+1}");
+        assertEcho(result, "04-$500");
+        // Inside an EL literal '\' is only used to escape '\', ''' and '"'
+        assertEcho(result, "05-\\$");
+        assertEcho(result, "06-\\${");
+        assertEcho(result, "10-2");
+        assertEcho(result, "11-${1+1}");
+        assertEcho(result, "12-\\2");
+        assertEcho(result, "13-\\${1+1}");
+        assertEcho(result, "14-\\\\2");
+        assertEcho(result, "15-$500");
+        assertEcho(result, "16-\\$");
+        assertEcho(result, "17-\\${");
+        assertEcho(result, "20-2");
+        assertEcho(result, "21-#{1+1}");
+        assertEcho(result, "22-\\2");
+        assertEcho(result, "23-\\#{1+1}");
+        assertEcho(result, "24-\\\\2");
+        assertEcho(result, "25-\\#");
+        assertEcho(result, "26-\\#{");
+
+        res = getUrl("http://localhost:" + getPort() + "/test/bug45nnn/bug45451c.jsp");
+        result = res.toString();
+        // Warning: JSP attribute escaping != Java String escaping
+        // TODO - Currently we allow a single unescaped \ in attribute values
+        //        Review if this should cause a warning/error
+        assertEcho(result, "00-${1+1}");
+        assertEcho(result, "01-\\${1+1}");
+        assertEcho(result, "02-\\\\${1+1}");
+        assertEcho(result, "03-\\\\\\${1+1}");
+        assertEcho(result, "04-\\$500");
+        assertEcho(result, "10-${1+1}");
+        assertEcho(result, "11-\\${1+1}");
+        assertEcho(result, "12-\\${1+1}");
+        assertEcho(result, "13-\\\\${1+1}");
+        assertEcho(result, "14-\\\\${1+1}");
+        assertEcho(result, "15-\\$500");
+        assertEcho(result, "20-#{1+1}");
+        assertEcho(result, "21-\\#{1+1}");
+        assertEcho(result, "22-\\#{1+1}");
+        assertEcho(result, "23-\\\\#{1+1}");
+        assertEcho(result, "24-\\\\#{1+1}");
+
+        res = getUrl("http://localhost:" + getPort() + "/test/bug45nnn/bug45451d.jspx");
+        result = res.toString();
+        // Warning: JSP attribute escaping != Java String escaping
+        // \\ Is *not* an escape sequence in XML attributes
+        assertEcho(result, "00-2");
+        assertEcho(result, "01-${1+1}");
+        assertEcho(result, "02-\\${1+1}");
+        assertEcho(result, "03-\\\\${1+1}");
+        assertEcho(result, "04-$500");
+        assertEcho(result, "10-2");
+        assertEcho(result, "11-${1+1}");
+        assertEcho(result, "12-\\${1+1}");
+        assertEcho(result, "13-\\\\${1+1}");
+        assertEcho(result, "14-\\\\\\${1+1}");
+        assertEcho(result, "15-$500");
+        assertEcho(result, "20-2");
+        assertEcho(result, "21-#{1+1}");
+        assertEcho(result, "22-\\#{1+1}");
+        assertEcho(result, "23-\\\\#{1+1}");
+        assertEcho(result, "24-\\\\\\#{1+1}");
+
+        res = getUrl("http://localhost:" + getPort() + "/test/bug45nnn/bug45451e.jsp");
+        result = res.toString();
+        // Warning: JSP attribute escaping != Java String escaping
+        // Warning: Attributes are always unescaped before passing to the EL
+        //          processor
+        assertEcho(result, "00-2");
+        assertEcho(result, "01-${1+1}");
+        assertEcho(result, "02-\\${1+1}");
+        assertEcho(result, "03-\\\\${1+1}");
+        assertEcho(result, "04-$500");
+        assertEcho(result, "10-2");
+        assertEcho(result, "11-${1+1}");
+        assertEcho(result, "12-\\2");
+        assertEcho(result, "13-\\${1+1}");
+        assertEcho(result, "14-\\\\2");
+        assertEcho(result, "15-$500");
+        assertEcho(result, "20-#{1+1}");
+        assertEcho(result, "21-\\#{1+1}");
+        assertEcho(result, "22-\\#{1+1}");
+        assertEcho(result, "23-\\\\#{1+1}");
+        assertEcho(result, "24-\\\\#{1+1}");
+    }
+
+    @Test
+    public void testBug45511() throws Exception {
+        getTomcatInstanceTestWebapp(false, true);
+
+        ByteChunk res = getUrl("http://localhost:" + getPort() +
+                "/test/bug45nnn/bug45511.jsp");
+
+        String result = res.toString();
+        assertEcho(result, "00-true");
+        assertEcho(result, "01-false");
+    }
+
+    @Test
+    public void testBug46596() throws Exception {
+        getTomcatInstanceTestWebapp(false, true);
+
+        ByteChunk res = getUrl("http://localhost:" + getPort() + "/test/bug46596.jsp");
+        String result = res.toString();
+        assertEcho(result, "{OK}");
+    }
+
+    @Test
+    public void testBug47413() throws Exception {
+        getTomcatInstanceTestWebapp(false, true);
+
+        ByteChunk res = getUrl("http://localhost:" + getPort() + "/test/bug47413.jsp");
+
+        String result = res.toString();
+        assertEcho(result, "00-hello world");
+        assertEcho(result, "01-hello world");
+        assertEcho(result, "02-3.22");
+        assertEcho(result, "03-3.22");
+        assertEcho(result, "04-17");
+        assertEcho(result, "05-17");
+        assertEcho(result, "06-hello world");
+        assertEcho(result, "07-hello world");
+        assertEcho(result, "08-0.0");
+        assertEcho(result, "09-0.0");
+        assertEcho(result, "10-0");
+        assertEcho(result, "11-0");
+    }
+
+    @Test
+    public void testBug48112() throws Exception {
+        getTomcatInstanceTestWebapp(false, true);
+
+        ByteChunk res = getUrl("http://localhost:" + getPort() +
+                "/test/bug48nnn/bug48112.jsp");
+        String result = res.toString();
+        assertEcho(result, "{OK}");
+    }
+
+    @Test
+    public void testBug49555() throws Exception {
+        getTomcatInstanceTestWebapp(false, true);
+
+        ByteChunk res = getUrl("http://localhost:" + getPort() + "/test/bug49nnn/bug49555.jsp");
+
+        String result = res.toString();
+        assertEcho(result, "00-" + TesterFunctions.Inner$Class.RETVAL);
+    }
+
+    @Test
+    public void testBug51544() throws Exception {
+        getTomcatInstanceTestWebapp(false, true);
+
+        ByteChunk res = getUrl("http://localhost:" + getPort() +
+                "/test/bug5nnnn/bug51544.jsp");
+
+        String result = res.toString();
+        assertEcho(result, "Empty list: true");
+    }
+
+    @Test
+    public void testELMiscNoQuoteAttributeEL() throws Exception {
+        doTestELMisc(false);
+    }
+
+    @Test
+    public void testELMiscWithQuoteAttributeEL() throws Exception {
+        doTestELMisc(true);
+    }
+
+    private void doTestELMisc(boolean quoteAttributeEL) throws Exception {
+        Tomcat tomcat = getTomcatInstance();
+
+        // Create the context (don't use addWebapp as we want to modify the
+        // JSP Servlet settings).
+        File appDir = new File("test/webapp");
+        StandardContext ctxt = (StandardContext) tomcat.addContext(
+                null, "/test", appDir.getAbsolutePath());
+
+        ctxt.addServletContainerInitializer(new JasperInitializer(), null);
+
+        // Configure the defaults and then tweak the JSP servlet settings
+        // Note: Min value for maxLoadedJsps is 2
+        Tomcat.initWebappDefaults(ctxt);
+        Wrapper w = (Wrapper) ctxt.findChild("jsp");
+
+        String jspName;
+        if (quoteAttributeEL) {
+            jspName = "/test/el-misc-with-quote-attribute-el.jsp";
+            w.addInitParameter("quoteAttributeEL", "true");
+        } else {
+            jspName = "/test/el-misc-no-quote-attribute-el.jsp";
+            w.addInitParameter("quoteAttributeEL", "false");
+        }
+
+        tomcat.start();
+
+        ByteChunk res = getUrl("http://localhost:" + getPort() + jspName);
+        String result = res.toString();
+
+        assertEcho(result, "00-\\\\\\\"${'hello world'}");
+        assertEcho(result, "01-\\\\\\\"\\${'hello world'}");
+        assertEcho(result, "02-\\\"${'hello world'}");
+        assertEcho(result, "03-\\\"\\hello world");
+        assertEcho(result, "2az-04");
+        assertEcho(result, "05-a2z");
+        assertEcho(result, "06-az2");
+        assertEcho(result, "2az-07");
+        assertEcho(result, "08-a2z");
+        assertEcho(result, "09-az2");
+        assertEcho(result, "10-${'foo'}bar");
+        assertEcho(result, "11-\\\"}");
+        assertEcho(result, "12-foo\\bar\\baz");
+        assertEcho(result, "13-foo\\bar\\baz");
+        assertEcho(result, "14-foo\\bar\\baz");
+        assertEcho(result, "15-foo\\bar\\baz");
+        assertEcho(result, "16-foo\\bar\\baz");
+        assertEcho(result, "17-foo\\&apos;bar&apos;\\&quot;baz&quot;");
+        assertEcho(result, "18-3");
+        assertEcho(result, "19-4");
+        assertEcho(result, "20-4");
+        assertEcho(result, "21-[{value=11}, {value=12}, {value=13}, {value=14}]");
+        assertEcho(result, "22-[{value=11}, {value=12}, {value=13}, {value=14}]");
+    }
+
+    @Test
+    public void testScriptingExpression() throws Exception {
+        getTomcatInstanceTestWebapp(false, true);
+
+        ByteChunk res = getUrl("http://localhost:" + getPort() + "/test/script-expr.jsp");
+        String result = res.toString();
+        assertEcho(result, "00-hello world");
+        assertEcho(result, "01-hello \"world");
+        assertEcho(result, "02-hello \\\"world");
+        assertEcho(result, "03-hello ${world");
+        assertEcho(result, "04-hello \\${world");
+        assertEcho(result, "05-hello world");
+        assertEcho(result, "06-hello \"world");
+        assertEcho(result, "07-hello \\\"world");
+        assertEcho(result, "08-hello ${world");
+        assertEcho(result, "09-hello \\${world");
+        assertEcho(result, "10-hello <% world");
+        assertEcho(result, "11-hello %> world");
+    }
+
+    @Test
+    public void testELMethod() throws Exception {
+        getTomcatInstanceTestWebapp(false, true);
+
+        ByteChunk res = getUrl("http://localhost:" + getPort() + "/test/el-method.jsp");
+        String result = res.toString();
+        assertEcho(result, "00-Hello JUnit from Tomcat");
+        assertEcho(result, "01-Hello JUnit from Tomcat");
+        assertEcho(result, "02-Hello JUnit from Tomcat");
+        assertEcho(result, "03-Hello JUnit from Tomcat");
+        assertEcho(result, "04-Hello JUnit from Tomcat");
+        assertEcho(result, "05-Hello JUnit from Tomcat");
+    }
+
+    @Test
+    public void testBug56029() throws Exception {
+        getTomcatInstanceTestWebapp(true, true);
+
+        ByteChunk res = getUrl("http://localhost:" + getPort() +
+                "/test/bug5nnnn/bug56029.jspx");
+
+        String result = res.toString();
+
+        Assert.assertTrue(result.contains("[1]:[1]"));
+    }
+
+
+    @Test
+    public void testBug56147() throws Exception {
+        getTomcatInstanceTestWebapp(true, true);
+
+        ByteChunk res = getUrl("http://localhost:" + getPort() +
+                "/test/bug5nnnn/bug56147.jsp");
+
+        String result = res.toString();
+        assertEcho(result, "00-OK");
+    }
+
+
+    @Test
+    public void testBug56612() throws Exception {
+        getTomcatInstanceTestWebapp(false, true);
+
+        ByteChunk res = getUrl("http://localhost:" + getPort() +
+                "/test/bug5nnnn/bug56612.jsp");
+
+        String result = res.toString();
+        Assert.assertTrue(result.contains("00-''"));
+    }
+
+
+    /*
+     * java.lang should be imported by default
+     */
+    @Test
+    public void testBug57141() throws Exception {
+        getTomcatInstanceTestWebapp(false, true);
+
+        ByteChunk res = getUrl("http://localhost:" + getPort() +
+                "/test/bug5nnnn/bug57141.jsp");
+
+        String result = res.toString();
+        assertEcho(result, "00-true");
+        assertEcho(result, "01-false");
+        assertEcho(result, "02-2147483647");
+    }
+
+
+    /*
+     * BZ https://bz.apache.org/bugzilla/show_bug.cgi?id=57142
+     * javax.servlet, javax.servlet.http and javax.servlet.jsp should be
+     * imported by default.
+     */
+    @Test
+    public void testBug57142() throws Exception {
+        getTomcatInstanceTestWebapp(false, true);
+
+        ByteChunk res = getUrl("http://localhost:" + getPort() +
+                "/test/bug5nnnn/bug57142.jsp");
+
+        String result = res.toString();
+        // javax.servlet
+        assertEcho(result, "00-" + DispatcherType.ASYNC);
+        // No obvious static fields for javax.servlet.http
+        // Could hack something with HttpUtils...
+        // No obvious static fields for javax.servlet.jsp
+        // Wild card (package) import
+        assertEcho(result, "01-" + RoundingMode.HALF_UP);
+        // Class import
+        assertEcho(result, "02-" + Collections.EMPTY_LIST.size());
+    }
+
+
+    /*
+     * BZ https://bz.apache.org/bugzilla/show_bug.cgi?id=57441
+     * Can't validate function names defined in lambdas (or via imports)
+     */
+    @Test
+    public void testBug57441() throws Exception {
+        getTomcatInstanceTestWebapp(false, true);
+
+        ByteChunk res = getUrl("http://localhost:" + getPort() +
+                "/test/bug5nnnn/bug57441.jsp");
+
+        String result = res.toString();
+        assertEcho(result, "00-11");
+    }
+
+
+    @Test
+    public void testBug60032() throws Exception {
+        getTomcatInstanceTestWebapp(false, true);
+
+        ByteChunk res = getUrl("http://localhost:" + getPort() + "/test/bug6nnnn/bug60032.jsp");
+        String result = res.toString();
+        assertEcho(result, "{OK}");
+    }
+
+
+    @Test
+    public void testBug60431() throws Exception {
+        getTomcatInstanceTestWebapp(false, true);
+
+        ByteChunk res = getUrl("http://localhost:" + getPort() + "/test/bug6nnnn/bug60431.jsp");
+        String result = res.toString();
+        assertEcho(result, "01-OK");
+        assertEcho(result, "02-OK");
+    }
+
+
+    @Test
+    public void testBug61854a() throws Exception {
+        getTomcatInstanceTestWebapp(true,  true);
+
+        ByteChunk res = getUrl("http://localhost:" + getPort() + "/test/bug6nnnn/bug61854.jsp");
+        String result = res.toString();
+        assertEcho(result, "01-OK");
+    }
+
+
+    // Assertion for text contained with <p></p>, e.g. printed by tags:echo
+    private static void assertEcho(String result, String expected) {
+        Assert.assertTrue(result, result.indexOf("<p>" + expected + "</p>") > 0);
+    }
+}

--- a/test/webapp/bug6nnnn/bug61854.jsp
+++ b/test/webapp/bug6nnnn/bug61854.jsp
@@ -1,0 +1,24 @@
+<%--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+--%>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="tags" tagdir="/WEB-INF/tags" %>
+<html>
+  <head><title>Bug 60431 test case</title></head>
+  <body>
+    <<tags:echo echo="0${ map = {'1':'2', 'a':'b'}; fn:length(map['a']) }-OK"/>
+  </body>
+</html>

--- a/webapps/docs/changelog.xml
+++ b/webapps/docs/changelog.xml
@@ -1,0 +1,4720 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE document [
+  <!ENTITY project SYSTEM "project.xml">
+]>
+<?xml-stylesheet type="text/xsl" href="tomcat-docs.xsl"?>
+<document url="changelog.html">
+
+  &project;
+
+  <properties>
+    <title>Changelog</title>
+    <no-comments />
+  </properties>
+
+<body>
+<!--
+  Subsection ordering:
+  General, Catalina, Coyote, Jasper, Cluster, WebSocket, Web applications,
+  Extras, Tribes, jdbc-pool, Other
+
+  Item Ordering:
+
+  Fixes having an issue number are sorted by their number, ascending.
+
+  There is no ordering by add/update/fix/scode.
+
+  Other fixed issues are added to the end of the list, chronologically.
+  They eventually become mixed with the numbered issues. (I.e., numbered
+  issues do not "pop up" wrt. others).
+-->
+<section name="Tomcat 9.0.3 (markt)" rtext="in development">
+  <subsection name="Catalina">
+    <changelog>
+      <fix>
+        Add some missing NPEs to ServletContext. (remm)
+      </fix>
+      <fix>
+        Update the Java EE 8 XML schema to the released versions. (markt)
+      </fix>
+      <fix>
+        Minor HTTP/2 push fixes. (remm)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Jasper">
+    <changelog>
+      <fix>
+        <bug>61854</bug>: When using sets and/or maps in EL expressions, ensure
+        that Jasper correctly parses the expression. Patch provided by Ricardo
+        Martin Camarero. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Coyote">
+    <changelog>
+      <add>
+        <bug>60276</bug>: Implement GZIP compression support for responses
+        served over HTTP/2. (markt)
+      </add>
+      <fix>
+        Do not call onDataAvailable without any data to read. (remm)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Web applications">
+    <changelog>
+      <add>
+        <bug>61223</bug>: Add the mbeans-descriptors.dtd file to the custom
+        MBean documentation so users have a reference to use when constructing
+        mbeans-descriptiors.xml files for custom components. (markt)
+      </add>
+    </changelog>
+  </subsection>
+  <subsection name="Other">
+    <changelog>
+      <fix>
+        Add an additional system property for the system property replacement.
+        (remm)
+      </fix>
+      <fix>
+        Add missing SHA-512 hash for release artifacts to the build script.
+        (markt)
+      </fix>
+      <update>
+        Update the internal fork of Commons Pool 2 to 2.4.3. (markt)
+      </update>
+      <update>
+        Update the internal fork of Commons DBCP 2 to 8a71764 (2017-10-18) to
+        pick up some bug fixes and enhancements. (markt)
+      </update>
+      <update>
+        Update the internal fork of Commons FileUpload to 6c00d57 (2017-11-23)
+        to pick up some code clean-up. (markt)
+      </update>
+      <update>
+        Update the internal fork of Commons Codec to r1817136 to pick up some
+        code clean-up. (markt)
+      </update>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.2 (markt)" rtext="2017-11-30">
+  <subsection name="Catalina">
+    <changelog>
+      <fix>
+        Fix possible <code>SecurityException</code> when using TLS related
+        request attributes. (markt)
+      </fix>
+      <fix>
+        <bug>61597</bug>: Extend the <code>StandardJarScanner</code> to scan
+        JARs on the module path when running on Java 9 and class path scanning
+        is enabled. (markt)
+      </fix>
+      <fix>
+        <bug>61601</bug>: Add support for multi-release JARs in JAR scanning and
+        web application class loading. (markt)
+      </fix>
+      <fix>
+        <bug>61681</bug>: Allow HTTP/2 push when using request wrapping. (remm)
+      </fix>
+      <add>
+        Provide the <code>SessionInitializerFilter</code> that can be used to
+        ensure that an HTTP session exists when initiating a WebSocket
+        connection. Patch provided by isapir. (markt)
+      </add>
+      <fix>
+        <bug>61682</bug>: When re-prioritising HTTP/2 streams, ensure that both
+        parent and children fields are correctly updated to avoid a possible
+        <code>StackOverflowError</code>. (markt)
+      </fix>
+      <fix>
+        Improve concurrency by reducing the scope of the synchronisation for
+        <code>javax.security.auth.message.config.AuthConfigFactory</code> in the
+        JASPIC API implementation. Based on a patch by Pavan Kumar. (markt)
+      </fix>
+      <fix>
+        Avoid a possible <code>NullPointerException</code> when timing out
+        <code>AsyncContext</code> instances during shut down. (markt)
+      </fix>
+      <fix>
+        <bug>61777</bug>: Avoid a <code>NullPointerException</code> when
+        detaching a JASPIC <code>RegistrationListener</code>. Patch provided by
+        Lazar. (markt)
+      </fix>
+      <fix>
+        <bug>61778</bug>: Correct the return value when detaching a JASPIC
+        <code>RegistrationListener</code>. Patch provided by Lazar. (markt)
+      </fix>
+      <fix>
+        <bug>61779</bug>: Avoid a <code>NullPointerException</code> when a
+        <code>null</code> <code>RegistrationListener</code> is passed to
+        <code>AuthConfigFactory.getConfigProvider()</code>. Patch provided by
+        Lazar. (markt)
+      </fix>
+      <fix>
+        <bug>61780</bug>: Only include the default JASPIC registration ID in the
+        return value for a call to
+        <code>AuthConfigFactory.getRegistrationIDs()</code> if a
+        <code>RegistrationContext</code> has been registered using the default
+        registration ID. Patch provided by Lazar. (markt)
+      </fix>
+      <fix>
+        <bug>61781</bug>: Enable JASPIC provider registrations to be persisted
+        when the layer and/or application context are <code>null</code>. Patch
+        provided by Lazar. (markt)
+      </fix>
+      <fix>
+        <bug>61782</bug>: When calling
+        <code>AuthConfigFactory.doRegisterConfigProvider()</code> and the
+        requested JASPIC config provider class is found by the web application
+        class loader, do not attempt to load the class with the class loader
+        that loaded the JASPIC API. Patch provided by Lazar. (markt)
+      </fix>
+      <fix>
+        <bug>61783</bug>: When calling
+        <code>AuthConfigFactory.removeRegistration()</code> and the registration
+        is persistent, it should be removed from the persistent store. Patch
+        provided by Lazar. (markt)
+      </fix>
+      <fix>
+        <bug>61784</bug>: Correctly handle the case when
+        <code>AuthConfigFactoryImpl.registerConfigProvider()</code> is called
+        with a provider name of <code>null</code>. Patch provided by Lazar.
+        (markt)
+      </fix>
+      <add>
+        <bug>61795</bug>: Add a property to the <code>Authenticator</code>
+        implementations to enable a custom JASPIC <code>CallbackHandler</code>
+        to be specified. Patch provided by Lazar. (markt)
+      </add>
+    </changelog>
+  </subsection>
+  <subsection name="Coyote">
+    <changelog>
+      <fix>
+        <bug>61568</bug>: Avoid a potential <code>SecurityException</code> when
+        using the NIO2 connector and a new thread is added to the pool. (markt)
+      </fix>
+      <fix>
+        <bug>61583</bug>: Correct a further regression in the fix to enable the
+        use of Java key stores that contained multiple keys that did not all
+        have the same password. This fixes PKCS11 key store handling with
+        multiple keys selected with an alias. (markt)
+      </fix>
+      <fix>
+        Improve NIO2 syncing for async IO operations. (remm)
+      </fix>
+      <add>
+        Sendfile support for HTTP/2 and NIO2. (remm)
+      </add>
+      <fix>
+        Reduce default HTTP/2 stream concurrent execution within a connection
+        from 200 to 20. (remm)
+      </fix>
+      <fix>
+        <bug>61668</bug>: Avoid a possible NPE when calling
+        <code>AbstractHttp11Protocol.getSSLProtocol()</code>. (markt)
+      </fix>
+      <fix>
+        <bug>61673</bug>: Avoid a possible
+        <code>ConcurrentModificationException</code> when working with the
+        streams associated with a connection. (markt)
+      </fix>
+      <fix>
+        <bug>61719</bug>: Avoid possible NPE calling
+        InputStream.setReadListener with HTTP/2. (remm)
+      </fix>
+      <fix>
+        <bug>61736</bug>: Improve performance of NIO connector when clients
+        leave large time gaps between network packets. Patch provided by Zilong
+        Song. (markt)
+      </fix>
+      <fix>
+        <bug>61740</bug>: Correct an off-by-one error in the Hpack header index
+        validation that caused intermittent request failures when using HTTP/2.
+        (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Jasper">
+    <changelog>
+      <fix>
+        <bug>61604</bug>: Fix SMAP generation for JSPs that generate no output.
+        (markt)
+      </fix>
+      <fix>
+        <bug>61816</bug>: Invalid expressions in attribute values or template
+        text should trigger a translation (compile time) error, not a run time
+        error. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="WebSocket">
+    <changelog>
+      <fix>
+        <bug>61604</bug>: Add support for authentication in the websocket
+        client. Patch submitted by J Fernandez. (remm)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Web applications">
+    <changelog>
+      <fix>
+        Correct Javadoc links to point to Java SE 8 and Java EE 8. (markt)
+      </fix>
+      <fix>
+        Enable Javadoc to be built with Java 9. (markt)
+      </fix>
+      <fix>
+        <bug>61603</bug>: Add XML filtering for the status servlet output where
+        needed. (remm)
+      </fix>
+      <fix>
+        Correct the description of how the CGI servlet maps a request to a
+        script in the CGI How-To. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Tribes">
+    <changelog>
+      <fix>
+        Fix incorrect behavior that attempts to resend channel messages more
+        than the actual setting value of <code>maxRetryAttempts</code>.
+        (kfujino)
+      </fix>
+      <fix>
+        Ensure that the remaining Sender can send channel messages by avoiding
+        unintended <code>ChannelException</code> caused by comparing the number
+        of failed members and the number of remaining Senders. (kfujino)
+      </fix>
+      <fix>
+        Ensure that remaining SelectionKeys that were not handled by throwing a
+        <code>ChannelException</code> during SelectionKey processing are
+        handled. (kfujino)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Other">
+    <changelog>
+      <fix>
+        Improve the fix for <bug>61439</bug> and exclude the JPA, JAX-WS and EJB
+        annotations completely from the Tomcat distributions. (markt)
+      </fix>
+      <fix>
+        Improve handling of endorsed directories. The endorsed directory
+        mechanism will only be used if the <code>JAVA_ENDORSED_DIRS</code>
+        system property is explicitly set or if
+        <code>$CATALINA_HOME/endorsed</code> exists. When running on Java 9, any
+        such attempted use of the endorsed directory mechanism will trigger an
+        error and Tomcat will fail to start. (rjung)
+      </fix>
+      <add>
+        <bug>51496</bug>: When using the Windows installer, check if the
+        requested service name already exists and, if it does, prompt the user
+        to select an alternative service name. Patch provided by Ralph
+        Plawetzki. (markt)
+      </add>
+      <fix>
+        <bug>61590</bug>: Enable <code>service.bat</code> to recognise when
+        <code>JAVA_HOME</code> is configured for a Java 9 JDK. (markt)
+      </fix>
+      <fix>
+        <bug>61598</bug>: Update the Windows installer to search the new (as of
+        Java 9) registry locations when looking for a JRE. (markt)
+      </fix>
+      <add>
+        Add generation of a SHA-512 hash for release artifacts to the build
+        script. (markt)
+      </add>
+      <fix>
+        <bug>61658</bug>: Update MIME mappings for fonts to use
+        <code>font/*</code> as per RFC8081. (markt)
+      </fix>
+      <update>
+        Update the packaged version of the Tomcat Native Library to 1.2.16 to
+        pick up the latest Windows binaries built with APR 1.6.3 and OpenSSL
+        1.0.2m. (markt)
+      </update>
+      <update>
+        Update the NSIS Installer used to build the Windows installer to version
+        3.02.1. (kkolinko)
+      </update>
+      <update>
+        Update the Windows installer to use "The Apache Software Foundation" as
+        the Publisher when Tomcat is displayed in the list of installed
+        applications in Microsoft Windows. (kkolinko)
+      </update>
+      <fix>
+        <bug>61803</bug>: Remove outdated SSL information from the Security
+        documentation. (remm)
+      </fix>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.1 (markt)" rtext="2017-09-30">
+  <subsection name="Catalina">
+    <changelog>
+      <fix>
+        Use the correct path when loading the JVM <code>logging.properties</code>
+        file for Java 9. (rjung)
+      </fix>
+      <fix>
+        Add additional validation to the resource handling required to fix
+        CVE-2017-12617 on Windows. The checks were being performed elsewhere but
+        adding them to the resource handling ensures that the checks are always
+        performed. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Other">
+    <changelog>
+      <fix>
+        <bug>61563</bug>: Correct typos in Spanish translation. Patch provided by
+        Gonzalo Vásquez. (csutherl)
+      </fix>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.0 (markt)" rtext="not released">
+  <subsection name="Catalina">
+    <changelog>
+      <fix>
+        <bug>61542</bug>: Fix CVE-2017-12617 and prevent JSPs from being
+        uploaded via a specially crafted request when HTTP PUT was enabled.
+        (markt)
+      </fix>
+      <fix>
+        <bug>61554</bug>: Exclude test files in unusual encodings and markdown
+        files intended for display in GitHub from RAT analysis. Patch provided
+        by Chris Thistlethwaite. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Coyote">
+    <changelog>
+      <add>
+        <bug>60762</bug>: Add the ability to make changes to the TLS
+        configuration of a connector at runtime without having to restart the
+        Connector. (markt)
+      </add>
+      <add>
+        Add an option to reject requests that contain HTTP headers with invalid
+        (non-token) header names with a 400 response and reject such requests by
+        default. (markt)
+      </add>
+      <fix>
+        Implement the requirements of RFC 7230 (and RFC 2616) that HTTP/1.1
+        requests must include a <code>Host</code> header and any request that
+        does not must be rejected with a 400 response. (markt)
+      </fix>
+      <fix>
+        Implement the requirements of RFC 7230 that any HTTP/1.1 request that
+        specifies a host in the request line, must specify the same host in the
+        <code>Host</code> header and that any such request that does not, must
+        be rejected with a 400 response. This check is optional but enabled by
+        default. It may be disabled with the
+        <code>allowHostHeaderMismatch</code> attribute of the Connector. (markt)
+      </fix>
+      <fix>
+        Implement the requirements of RFC 7230 that any HTTP/1.1 request that
+        contains multiple <code>Host</code> headers is rejected with a 400
+        response. (markt)
+      </fix>
+      <update>
+        Add a way to set the property source in embedded mode. (remm)
+      </update>
+      <fix>
+        <bug>61557</bug>: Correct a further regression in the fix to enable the
+        use of Java key stores that contain multiple keys that do not all have
+        the same password. The regression broke support for some FIPS compliant
+        key stores. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="jdbc-pool">
+    <changelog>
+      <fix>
+        <bug>61545</bug>: Correctly handle invocations of methods defined in the
+        <code>PooledConnection</code> interface when using pooled XA
+        connections. Patch provided by Nils Winkler. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Other">
+    <changelog>
+      <fix>
+        Update fix for <bug>59904</bug> so that values less than zero are accepted
+        instead of throwing a NegativeArraySizeException. (remm)
+      </fix>
+      <add>
+        Complete the implementation of the Servlet 4.0 specification. (markt)
+      </add>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.0.M27 (markt)" rtext="2017-09-19">
+  <subsection name="Catalina">
+    <changelog>
+      <fix>
+        Before generating an error page in the <code>ErrorReportValve</code>,
+        check to see if I/O is still permitted for the associated connection
+        before generating the error page so that the page generation can be
+        skipped if the page is never going to be sent. (markt)
+      </fix>
+      <add>
+        <bug>61189</bug>: Add the ability to set environment variables for
+        individual CGI scripts. Based on a patch by jm009. (markt)
+      </add>
+      <fix>
+        <bug>61210</bug>: When running under a SecurityManager, do not print a
+        warning about not being able to read a logging configuration file when
+        that file does not exist. (markt)
+      </fix>
+      <add>
+        <bug>61280</bug>: Add RFC 7617 support to the
+        <code>BasicAuthenticator</code>. Note that the default configuration
+        does not change the existing behaviour. (markt)
+      </add>
+      <fix>
+        <bug>61424</bug>: Avoid a possible <code>StackOverflowError</code> when
+        running under a <code>SecurityManager</code> and using
+        <code>Subject.doAs()</code>. (markt)
+      </fix>
+      <add>
+        When running under Java 9 or later, and the
+        <code>urlCacheProtection</code> option of the
+        <code>JreMemoryLeakPreventionListener</code> is enabled, use the API
+        added in Java 9 to only disable the caching for JAR URL connections.
+        (markt)
+      </add>
+      <add>
+        <bug>61489</bug>: When using the CGI servlet, make the generation of
+        command line arguments from the query string (as per section 4.4 of RFC
+        3875) optional and disabled by default. Based on a patch by jm009.
+        (markt)
+      </add>
+      <fix>
+        <bug>61503</bug>: This corrects a potential regression in the fix for
+        <bug>60940</bug> with an alternative solution that adds the
+        <code>JarEntry</code> objects normally skipped by a
+        <code>JarInputStream</code> only if those entries exist. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Coyote">
+    <changelog>
+      <update>
+        The minimum required Tomcat Native version has been increased to 1.2.14.
+        This version includes a new API needed for correct client certificate
+        support when using a Java connector with OpenSSL TLS implementation and
+        support for the <code>SSL_CONF</code> OpenSSL API. (rjung)
+      </update>
+      <add>
+        Add support for the OpenSSL <code>SSL_CONF</code> API when using
+        TLS with OpenSSL implementation. It can be used by adding
+        <code>OpenSSLConf</code> elements underneath <code>SSLHostConfig</code>.
+        The new element contains a list of <code>OpenSSLConfCmd</code> elements,
+        each with the attributes <code>name</code> and <code>value</code>.
+        (rjung)
+      </add>
+      <fix>
+        When using a Java connector in combination with the OpenSSL TLS
+        implementation, do not configure each SSL connection object via
+        the OpenSSLEngine. For OpenSSL the SSL object inherits its
+        settings from the SSL_CTX which we have already configured.
+        (rjung)
+      </fix>
+      <fix>
+        When using JSSE TLS configuration with the OpenSSL implementation and
+        client certificates: include client CA subjects in the TLS handshake
+        so that the client can choose an appropriate client certificate to
+        present. (rjung)
+      </fix>
+      <fix>
+        If an invalid option is specified for the
+        <code>certificateVerification</code> attribute of an
+        <code>SSLHostConfig</code> element, treat it as <code>required</code>
+        which is the most secure / restrictive option in addition to reporting
+        the configuration error. (markt)
+      </fix>
+      <fix>
+        Improve the handling of client disconnections during the TLS
+        renegotiation handshake. (markt)
+      </fix>
+      <fix>
+        Prevent exceptions being thrown during normal shutdown of NIO
+        connections. This enables TLS connections to close cleanly. (markt)
+      </fix>
+      <fix>
+        Fix possible race condition when setting IO listeners on an upgraded
+        connection. (remm)
+      </fix>
+      <fix>
+        Ensure that the APR/native connector uses blocking I/O for TLS
+        renegotiation. (markt)
+      </fix>
+      <fix>
+        <bug>48655</bug>: Enable Tomcat to shutdown cleanly when using sendfile,
+        the APR/native connector and a multi-part download is in progress.
+        (markt)
+      </fix>
+      <fix>
+        <bug>58244</bug>: Handle the case when OpenSSL resumes a TLS session
+        using a ticket and the full client certificate chain is not available.
+        In this case the client certificate without the chain will be presented
+        to the application. (markt)
+      </fix>
+      <fix>
+        Improve the warning message when JSSE and OpenSSL configuration styles
+        are mixed on the same <code>SSLHostConfig</code>. (markt)
+      </fix>
+      <fix>
+        <bug>61415</bug>: Fix TLS renegotiation with OpenSSL based connections
+        and session caching. (markt)
+      </fix>
+      <fix>
+        Delay checking that the configured attributes for an
+        <code>SSLHostConfig</code> instance are consistent with the configured
+        SSL implementation until <code>Connector</code> start to avoid incorrect
+        warnings when the SSL implementation changes during initialisation.
+        (markt)
+      </fix>
+      <fix>
+        <bug>61450</bug>: Fix default key alias algorithm. (remm)
+      </fix>
+      <fix>
+        <bug>61451</bug>: Correct a regression in the fix to enable the use of
+        Java key stores that contained multiple keys that did not all have the
+        same password. The regression broke support for any key store that did
+        not store keys in PKCS #8 format such as hardware key stores and Windows
+        key stores. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="WebSocket">
+    <changelog>
+      <fix>
+        <bug>60523</bug>: Reduce the number of packets used to send WebSocket
+        messages by not flushing between the header and the payload when the
+        two are written together. (markt)
+      </fix>
+      <fix>
+        <bug>61491</bug>: When using the <code>permessage-deflate</code>
+        extension, correctly handle the sending of empty messages after
+        non-empty messages to avoid the <code>IllegalArgumentException</code>.
+        (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Web applications">
+    <changelog>
+      <fix>
+        Show connector cipher list in the manager web application in the
+        correct cipher order. (rjung)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Tribes">
+    <changelog>
+      <fix>
+        To avoid unexpected session timeout notification from backup session,
+        update the access time when receiving the map member notification
+        message. (kfujino)
+      </fix>
+      <fix>
+        Add member info to the log message when the failure detection check
+        fails in <code>TcpFailureDetector</code>. (kfujino)
+      </fix>
+      <fix>
+        Avoid Ping timeout until the added map member by receiving
+        <code>MSG_START</code> message is completely started. (kfujino)
+      </fix>
+      <fix>
+        When sending a channel message, make sure that the Sender has connected.
+        (kfujino)
+      </fix>
+      <fix>
+        Correct the backup node selection logic that node 0 is returned twice
+        consecutively. (kfujino)
+      </fix>
+      <fix>
+        Fix race condition of <code>responseMap</code> in
+        <code>RpcChannel</code>. (kfujino)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="jdbc-pool">
+    <changelog>
+      <fix>
+        <bug>61391</bug>: Ensure that failed queries are logged if the
+        <code>SlowQueryReport</code> interceptor is configured to do so and the
+        connection has been abandoned. Patch provided by Craig Webb. (markt)
+      </fix>
+      <fix>
+        <bug>61425</bug>: Ensure that transaction of idle connection has
+        terminated  when the <code>testWhileIdle</code> is set to
+        <code>true</code> and <code>defaultAutoCommit</code> is set to
+        <code>false</code>. Patch provided by WangZheng. (kfujino)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Other">
+    <changelog>
+      <fix>
+        <bug>61419</bug>: Replace a Unix style comment in the DOS bat file
+        <code>catalina.bat</code> with the correct <code>rem</code> markup.
+        (rjung)
+      </fix>
+      <fix>
+        <bug>61439</bug>: Remove the Java Annotation API classes from
+        tomcat-embed-core.jar and package them in a separate JAR in the
+        embedded distribution to provide end users with greater flexibility to
+        handle potential conflicts with the JRE and/or other JARs. (markt)
+      </fix>
+      <fix>
+        <bug>61441</bug>: Improve the detection of <code>JAVA_HOME</code> by the
+        <code>daemon.sh</code> script when running on a platform where Java has
+        been installed from an RPM. (rjung)
+      </fix>
+      <update>
+        Update the packaged version of the Tomcat Native Library to 1.2.14 to
+        pick up the latest Windows binaries built with APR 1.6.2 and OpenSSL
+        1.0.2l. (markt)
+      </update>
+      <update>
+        <bug>61599</bug>: Update to Commons Daemon 1.1.0 for improved Java 9
+        support. (markt)
+      </update>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.0.M26 (markt)" rtext="2017-08-08">
+  <subsection name="Catalina">
+    <changelog>
+      <fix>
+        Correct multiple regressions in the fix for <bug>49464</bug> that could
+        corrupt static content served by the <code>DefaultServlet</code>.(markt)
+      </fix>
+      <fix>
+        Correct a bug in the <code>PushBuilder</code> implementation that
+        meant push URLs containing <code>%nn</code> sequences were not correctly
+        decoded. Identified by FindBugs. (markt)
+      </fix>
+      <add>
+        <bug>61164</bug>: Add support for the <code>%X</code> pattern in the
+        <code>AccessLogValve</code> that reports the connection status at the
+        end of the request. Patch provided by Zemian Deng. (markt)
+      </add>
+      <fix>
+        <bug>61351</bug>: Correctly handle %nn decoding of URL patterns in
+        web.xml and similar locations that may legitimately contain characters
+        that are not permitted by RFC 3986. (markt)
+      </fix>
+      <add>
+        <bug>61366</bug>: Add a new attribute, <code>localDataSource</code>, to
+        the <code>JDBCStore</code> that allows the Store to be configured to use
+        a DataSource defined by the web application rather than the default of
+        using a globally defined DataSource. Patch provided by Jonathan
+        Horowitz. (markt)
+      </add>
+    </changelog>
+  </subsection>
+  <subsection name="Coyote">
+    <changelog>
+      <fix>
+        <bug>61086</bug>: Ensure to explicitly signal an empty request body for
+        HTTP 205 responses. Additional fix to r1795278. Based on a patch
+        provided by Alexandr Saperov. (violetagg)
+      </fix>
+      <update>
+        <bug>61345</bug>: Add a server listener that can be used to do system
+        property replacement from the property source configured in the
+        digester. (remm)
+      </update>
+      <add>
+        Add additional logging to record problems that occur while waiting for
+        the NIO pollers to stop during the Connector stop process. (markt)
+      </add>
+    </changelog>
+  </subsection>
+  <subsection name="Jasper">
+    <changelog>
+      <fix>
+        <bug>61364</bug>: Ensure that files are closed after detecting encoding
+        of JSPs so that files do not remain locked by the file system. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="WebSocket">
+    <changelog>
+      <add>
+        <bug>57767</bug>: Add support to the WebSocket client for following
+        redirects when attempting to establish a WebSocket connection. Patch
+        provided by J Fernandez. (markt)
+      </add>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.0.M25 (markt)" rtext="2017-07-28">
+  <subsection name="Catalina">
+    <changelog>
+      <fix>
+        Performance improvements for service loader look-ups (and look-ups of
+        other class loader resources) when the web application is deployed in a
+        packed WAR file. (markt)
+      </fix>
+      <fix>
+        <bug>60963</bug>: Add <code>ExtractingRoot</code>, a new
+        <code>WebResourceRoot</code> implementation that extracts JARs to the
+        work directory for improved performance when deploying packed WAR files.
+        (markt)
+      </fix>
+      <fix>
+        <bug>61253</bug>: Add warn message when Digester.updateAttributes
+        throws an exception instead of ignoring it. (csutherl)
+      </fix>
+      <fix>
+        Correct a further regression in the fix for <bug>49464</bug> that could
+        cause an byte order mark character to appear at the start of content
+        included by the <code>DefaultServlet</code>. (markt)
+      </fix>
+      <fix>
+        <bug>61313</bug>: Make the read timeout configurable in the
+        <code>JNDIRealm</code> and ensure that a read timeout will result in an
+        attempt to fail over to the alternateURL. Based on patches by Peter
+        Maloney and Felix Schumacher. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Web applications">
+    <changelog>
+      <fix>
+        Correct the documentation for how <code>StandardRoot</code> is
+        configured. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Other">
+    <changelog>
+      <fix>
+        <bug>61316</bug>: Fix corruption of UTF-16 encoded source files in
+        released source distributions. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.0.M24 (markt)" rtext="not released">
+  <subsection name="Catalina">
+    <changelog>
+      <add>
+        <bug>52924</bug>: Add support for a Tomcat specific deployment
+        descriptor, <code>/WEB-INF/tomcat-web.xml</code>. This descriptor has an
+        identical format to <code>/WEB-INF/web.xml</code>. The Tomcat descriptor
+        takes precedence over any settings in <code>conf/web.xml</code> but does
+        not take precedence over any settings in <code>/WEB-INF/web.xml</code>.
+        (markt)
+      </add>
+      <fix>
+        <bug>61232</bug>: When log rotation is disabled only one separator will
+        be used when generating the log file name. For example if the prefix is
+        <code>catalina.</code> and the suffix is <code>.log</code> then the log
+        file name will be <code>catalina.log</code> instead of
+        <code>catalina..log</code>. Patch provided by Katya Stoycheva.
+        (violetagg)
+      </fix>
+      <fix>
+        <bug>61264</bug>: Correct a regression in the refactoring to use
+        <code>Charset</code> rather than <code>String</code> to store request
+        character encoding that prevented <code>getReader()</code> throwing an
+        <code>UnsupportedEncodingException</code> if the user agent specifies
+        an unsupported character encoding. (markt)
+      </fix>
+      <fix>
+        Correct a regression in the fix for <bug>49464</bug> that could cause an
+        incorrect <code>Content-Length</code> header to be sent by the
+        <code>DefaultServlet</code> if the encoding of a static is not
+        consistent with the encoding of the response. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Coyote">
+    <changelog>
+      <fix>
+        Enable TLS connectors to use Java key stores that contain multiple keys
+        where each key has a separate password. Based on a patch by Frank
+        Taffelt. (markt)
+      </fix>
+      <fix>
+        Improve the handling of HTTP/2 stream resets due to excessive headers
+        when a continuation frame is used. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Jasper">
+    <changelog>
+      <add>
+        <bug>53031</bug>: Add support for the <code>fork</code> option when
+        compiling JSPs with the Jasper Ant task and javac. (markt)
+      </add>
+    </changelog>
+  </subsection>
+  <subsection name="Other">
+    <changelog>
+      <add>
+        <bug>52791</bug>: Add the ability to set the defaults used by the
+        Windows installer from a configuration file. Patch provided by Sandra
+        Madden. (markt)
+      </add>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.0.M23 (markt)" rtext="not released">
+  <subsection name="Catalina">
+    <changelog>
+      <fix>
+        <bug>49464</bug>: Improve the Default Servlet's handling of static files
+        when the file encoding is not compatible with the required response
+        encoding. (markt)
+      </fix>
+      <fix>
+        <bug>61214</bug>: Remove deleted attribute <code>servlets</code> from
+        the Context MBean description. Patch provided by Alexis Hassler. (markt)
+      </fix>
+      <fix>
+        <bug>61215</bug>: Correctly define <code>addConnectorPort</code> and
+        <code>invalidAuthenticationWhenDeny</code> in the
+        <code>mbean-descriptors.xml</code> file for the
+        <code>org.apache.catalina.valves</code> package so that the attributes
+        are accessible via JMX. (markt)
+      </fix>
+      <fix>
+        <bug>61216</bug>: Improve layout for <code>CompositeData</code> and
+        <code>TabularData</code> when viewing via the JMX proxy servlet. Patch
+        provided by Alexis Hassler. (markt)
+      </fix>
+      <fix>
+        Additional permission for deleting files is granted to JULI as it is
+        required by FileHandler when running under a Security Manager. The
+        thread that cleans the log files is marked as daemon thread.
+        (violetagg)
+      </fix>
+      <fix>
+        <bug>61229</bug>: Correct a regression in 9.0.0.M21 that broke WebDAV
+        handling for resources with names that included a <code>&amp;</code>
+        character. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Coyote">
+    <changelog>
+      <fix>
+        Restore the ability to configure support for SSLv3. Enabling this
+        protocol will trigger a warning in the logs since it is known to be
+        insecure. (markt)
+      </fix>
+      <add>
+        Add LoadBalancerDrainingValve, a Valve designed to reduce the amount of
+        time required for a node to drain its authenticated users. (schultz)
+      </add>
+      <fix>
+        Do not log a warning when a <code>null</code> session is returned for an
+        OpenSSL based TLS session since this is expected when session tickets
+        are enabled. (markt)
+      </fix>
+      <fix>
+        When the access log valve logs a TLS related request attribute and the
+        NIO2 connector is used with OpenSSL, ensure that the TLS attributes are
+        available to the access log valve when the connection is closing.
+        (markt)
+      </fix>
+      <fix>
+        <bug>60461</bug>: Sync SSL session access for the APR connector. (remm)
+      </fix>
+      <fix>
+        <bug>61224</bug>: Make the <code>GlobalRequestProcessor</code> MBean
+        attributes read-only. Patch provided by Alexis Hassler. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Jasper">
+    <changelog>
+      <fix>
+        <bug>49176</bug>: When generating JSP runtime error messages that quote
+        the relevant JSP source code, switch from using the results of the JSP
+        page parsing process to using the JSR 045 source map data to identify
+        the correct part of the JSP source from the stack trace. This
+        significantly reduces the memory footprint of Jasper in development
+        mode, provides a small performance improvement for error page generation
+        and enables source quotes to continue to be provided after a Tomcat
+        restart. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Web applications">
+    <changelog>
+      <fix>
+        Remove references to the Loader attribute
+        <code>searchExternalFirst</code> from the documentation since the
+        attribute is no longer supported. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Tribes">
+    <changelog>
+      <add>
+        <bug>51513</bug>: Add support for the <code>compressionMinSize</code>
+        attribute to the <code>GzipInterceptor</code>, add optional statistics
+        collection and expose the Interceptor over JMX. Based on a patch by
+        Christian Stöber. (markt)
+      </add>
+      <add>
+        <bug>61127</bug>Allow human-readable names for channelSendOptions and
+        mapSendOptions. Patch provided by Igal Sapir. (schultz)
+      </add>
+    </changelog>
+  </subsection>
+  <subsection name="Other">
+    <changelog>
+      <scode>
+        Restore the local definition of the web service annotations since the
+        JRE provided versions are deprecated and Java 9 does not provide them by
+        default. (markt)
+      </scode>
+      <fix>
+        Add necessary Java 9 configuration options to the startup scripts to
+        prevent warnings being generated on web application stop. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.0.M22 (markt)" rtext="2017-06-26">
+  <subsection name="Catalina">
+    <changelog>
+      <fix>
+        <bug>48543</bug>: Add the option to specify an alternative file name for
+        the <code>catalina.config</code> system property. Also document that
+        relative, as well as absolute, URLs are permitted. (markt)
+      </fix>
+      <fix>
+        <bug>61072</bug>: Respect the documentation statements that allow
+        using the platform default secure random for session id generation.
+        (remm)
+      </fix>
+      <fix>
+        Correct the javadoc for
+        <code>o.a.c.connector.CoyoteAdapter#parseSessionCookiesId</code>.
+        Patch provided by John Andrew (XUZHOUWANG) via Github. (violetagg)
+      </fix>
+      <fix>
+        <bug>61101</bug>: CORS filter should set Vary header in response.
+        Submitted by Rick Riemer. (remm)
+      </fix>
+      <add>
+        <bug>61105</bug>: Add a new JULI FileHandler configuration for
+        specifying the maximum number of days to keep the log files. By default
+        the log files will be kept 90 days as configured in
+        <code>logging.properties</code>. (violetagg)
+      </add>
+      <update>
+        Update the Servlet 4.0 implementation to add support for setting
+        trailer fields for HTTP responses. (markt)
+      </update>
+      <fix>
+        <bug>61125</bug>: Ensure that <code>WarURLConnection</code> returns the
+        correct value for calls to <code>getLastModified()</code> as this is
+        required for the correct detection of JSP modifications when the JSP is
+        packaged in a WAR file. (markt)
+      </fix>
+      <fix>
+        Improve the <code>SSLValve</code> so it is able to handle client
+        certificate headers from Nginx. Based on a patch by Lucas Ventura Carro.
+        (markt)
+      </fix>
+      <fix>
+        <bug>61134</bug>: Do not use '[' and ']' symbols around substituted
+        text fragments when generating the default error pages. Patch provided
+        by Katya Todorova. (violetagg)
+      </fix>
+      <fix>
+        <bug>61154</bug>: Allow the Manager and Host Manager web applications to
+        start by default when running under a security manager. This was
+        accomplished by adding a custom permission,
+        <code>org.apache.catalina.security.DeployXmlPermission</code>, that
+        permits an application to use a <code>META-INF/context.xml</code> file
+        and then granting that permission to the Manager and Host Manager.
+        (markt)
+      </fix>
+      <fix>
+        <bug>61173</bug>: Polish the javadoc for
+        <code>o.a.catalina.startup.Tomcat</code>. Patch provided by
+        peterhansson_se. (violetagg)
+      </fix>
+      <add>
+        A new configuration property <code>crawlerIps</code> is added to the
+        <code>o.a.catalina.valves.CrawlerSessionManagerValve</code>. Using this
+        property one can specify a regular expression that will be used to
+        identify crawlers based on their IP address. Based on a patch provided
+        by Tetradeus. (violetagg)
+      </add>
+      <fix>
+        <bug>61180</bug>: Log a warning message rather than an information
+        message if it takes more than 100ms to initialised a
+        <code>SecureRandom</code> instance for a web application to use to
+        generate session identifiers. Patch provided by Piotr Chlebda. (markt)
+      </fix>
+      <fix>
+        <bug>61185</bug>: When an asynchronous request is dispatched via
+        <code>AsyncContext.dispatch()</code> ensure that
+        <code>getRequestURI()</code> for the dispatched request matches that of
+        the original request. (markt)
+      </fix>
+      <fix>
+        <bug>61197</bug>: Ensure that the charset name used in the
+        <code>Content-Type</code> header has exactly the same form as that
+        provided by the application. This reverts a behavioural change in
+        9.0.0.M21 that caused problems for some clients. (markt)
+      </fix>
+      <fix>
+        <bug>61201</bug>: Ensure that the <code>SCRIPT_NAME</code> environment
+        variable for CGI executables is populated in a consistent way regardless
+        of how the CGI servlet is mapped to a request. (markt)
+      </fix>
+      <fix>
+        Ensure to send a space between trailer field name and field value
+        for HTTP responses trailer fields. (huxing)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Coyote">
+    <changelog>
+      <fix>
+        <bug>61086</bug>: Explicitly signal an empty request body for HTTP 205
+        responses. (markt)
+      </fix>
+      <fix>
+        <bug>61120</bug>: Do not ignore path parameters when processing HTTP/2
+        requests. (markt)
+      </fix>
+      <fix>
+        Revert a change introduced in the fix for bug <bug>60718</bug> that
+        changed the status code recorded in the access log when the client
+        dropped the connection from 200 to 500. (markt)
+      </fix>
+      <fix>
+        Make asynchronous error handling more robust. In particular ensure that
+        <code>onError()</code> is called for any registered
+        <code>AsyncListener</code>s after an I/O error on a non-container
+        thread. (markt)
+      </fix>
+      <fix>
+        Add additional syncs to the SSL session object provided by the OpenSSL
+        engine so that a concurrent destruction cannot cause a JVM crash.
+        (remm)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Jasper">
+    <changelog>
+      <fix>
+        <bug>44787</bug>: Improve error message when JSP compiler configuration
+        options are not valid. (markt)
+      </fix>
+      <add>
+        <bug>45931</bug>: Extend Jasper's <code>timeSpaces</code> option to add
+        support for <code>single</code> which replaces template text that
+        consists entirely of whitespace with a single space character. Based on
+        a patch by Meetesh Karia. (markt)
+      </add>
+      <fix>
+        <bug>53011</bug>: When pre-compiling with JspC, report all compilation
+        errors rather than stopping after the first error. A new option
+        <code>-failFast</code> can be used to restore the previous behaviour of
+        stopping after the first error. Based on a patch provided by Marc Pompl.
+        (markt)
+      </fix>
+      <fix>
+        <bug>61137</bug>: <code>j.s.jsp.tagext.TagLibraryInfo#uri</code> and
+        <code>j.s.jsp.tagext.TagLibraryInfo#prefix</code> fields should not be
+        final. Patch provided by Katya Todorova. (violetagg)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="WebSocket">
+    <changelog>
+      <fix>
+        Correct the log message when a <code>MessageHandler</code> for
+        <code>PongMessage</code> does not implement
+        <code>MessageHandler.Whole</code>. (rjung)
+      </fix>
+      <fix>
+        Improve thread-safety of <code>Future</code>s used to report the result
+        of sending WebSocket messages. (markt)
+      </fix>
+      <fix>
+        <bug>61183</bug>: Correct a regression in the previous fix for
+        <bug>58624</bug> that could trigger a deadlock depending on the locking
+        strategy employed by the client code. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Web applications">
+    <changelog>
+      <fix>
+        Better document the meaning of the trimSpaces option for Jasper. (markt)
+      </fix>
+      <fix>
+        <bug>61150</bug>: Configure the Manager and Host-Manager web
+        applications to permit serialization and deserialization of
+        CRSFPreventionFilter related session objects to avoid warning messages
+        and/or stack traces on web application stop and/or start when running
+        under a security manager. (markt)
+      </fix>
+      <fix>
+        Correct the TLS configuration documentation to remove SSLv2 and SSLv3
+        from the list of supported protocols. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Other">
+    <changelog>
+      <add>
+        <bug>45832</bug>: Add HTTP DIGEST authentication support to the Catalina
+        Ant tasks used to communicate with the Manager application. (markt)
+      </add>
+      <fix>
+        <bug>45879</bug>: Add the <code>RELEASE-NOTES</code> file to the root of
+        the installation created by the Tomcat installer for Windows to make it
+        easier for users to identify the installed Tomcat version. (markt)
+      </fix>
+      <fix>
+        <bug>61055</bug>: Clarify the code comments in the rewrite valve to make
+        clear that there are no plans to provide proxy support for this valve
+        since Tomcat does not have proxy capabilities. (markt)
+      </fix>
+      <fix>
+        <bug>61076</bug>: Document the <code>altDDName</code> attribute for the
+        <code>Context</code> element. (markt)
+      </fix>
+      <fix>
+        Correct typo in Jar Scan Filter Configuration Reference.
+        Issue reported via comments.apache.org. (violetagg)
+      </fix>
+      <fix>
+        Correct the requirement for the minimum Java SE version in Application
+        Developer's Guide. Issue reported via comments.apache.org. (violetagg)
+      </fix>
+      <fix>
+        <bug>61145</bug>: Add missing <code>@Documented</code> annotation to
+        annotations in the annotations API. Patch provided by Katya Todorova.
+        (markt)
+      </fix>
+      <fix>
+        <bug>61146</bug>: Add missing <code>lookup()</code> method to
+        <code>@EJB</code> annotation in the annotations API. Patch provided by
+        Katya Todorova. (markt)
+      </fix>
+      <fix>
+        Correct typo in Context Container Configuration Reference.
+        Patch provided by Katya Todorova. (violetagg)
+      </fix>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.0.M21 (markt)" rtext="2017-05-10">
+  <subsection name="General">
+    <changelog>
+      <add>
+        Allow to exclude JUnit test classes using the build property
+        <code>test.exclude</code> and document the property in
+        BUILDING.txt. (rjung)
+      </add>
+    </changelog>
+  </subsection>
+  <subsection name="Catalina">
+    <changelog>
+      <fix>
+        Review those places where Tomcat re-encodes a URI or URI component and
+        ensure that that correct encoding (path differs from query string) is
+        applied and that the encoding is applied consistently. (markt)
+      </fix>
+      <fix>
+        Avoid a <code>NullPointerException</code> when reading attributes for a
+        initialised HTTP connector where TLS is enabled. (markt)
+      </fix>
+      <fix>
+        Always quote the <code>hostName</code> of an <code>SSLHostConfig</code>
+        element when using it as part of the JMX object name to avoid errors that
+        prevent the associated TLS connector from starting if a wild card
+        <code>hostName</code> is configured (because <code>*</code> is a
+        reserved character for JMX object names). (markt)
+      </fix>
+      <update>
+        Update the default <code>URIEncoding</code> for a <code>Connector</code>
+        to <code>UTF-8</code> as required by the Servlet 4.0 specification.
+        (markt)
+      </update>
+      <scode>
+        Switch to using <code>Charset</code> rather than <code>String</code> to
+        store encoding settings (including for configuration and for the
+        <code>Content-Type header</code>) to reduce the number of places the
+        associated <code>Charset</code> needs to be looked up. (markt)
+      </scode>
+      <fix>
+        Use a more reliable mechanism for the <code>DefaultServlet</code> when
+        determining if the current request is for custom error page or not.
+        (markt)
+      </fix>
+      <fix>
+        Ensure that when the Default or WebDAV servlets process an error
+        dispatch that the error resource is processed via the
+        <code>doGet()</code> method irrespective of the method used for the
+        original request that triggered the error. (markt)
+      </fix>
+      <fix>
+        If a static custom error page is specified that does not exist or cannot
+        be read, ensure that the intended error status is returned rather than a
+        404 or 403. (markt)
+      </fix>
+      <fix>
+        When the WebDAV servlet is configured and an error dispatch is made to a
+        custom error page located below <code>WEB-INF</code>, ensure that the
+        target error page is displayed rather than a 404 response. (markt)
+      </fix>
+      <update>
+        Update the Servlet 4.0 implementation to add support for obtaining
+        trailer fields from chunked HTTP requests. (markt)
+      </update>
+      <add>
+        <bug>61047</bug>: Add MIME mapping for woff2 fonts in the default
+        web.xml. Patch provided by Justin Williamson. (violetagg)
+      </add>
+      <fix>
+        Correct the logic that selects the encoding to use to decode the query
+        string in the <code>SSIServletExternalResolver</code> so that the
+        <code>useBodyEncodingForURI</code> attribute of the
+        <code>Connector</code> is correctly taken into account. (markt)
+      </fix>
+      <fix>
+        Within the Expires filter, make the content type value specified with the
+        <code>ExpiresByType</code> parameter, case insensitive. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Coyote">
+    <changelog>
+      <fix>
+        When a <code>TrustManager</code> is configured that does not support
+        <code>certificateVerificationDepth</code> only log a warning about that
+        lack of support when <code>certificateVerificationDepth</code> has been
+        explicitly set. (markt)
+      </fix>
+      <fix>
+        <bug>60970</bug>: Extend the fix for large headers to push requests.
+        (markt)
+      </fix>
+      <fix>
+        Do not include a <code>Date</code> header in HTTP/2 responses with
+        status codes less than 200. (markt)
+      </fix>
+      <fix>
+        When sending an HTTP/2 push promise with the NIO2 connector, the pushed
+        stream ID should only be included with the initial push promise frame
+        and not any subsequent continuation frames. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Jasper">
+    <changelog>
+      <fix>
+        When no BOM is present and an encoding is detected, do not skip the
+        bytes used to detect the encoding since they are not part of a BOM.
+        (markt)
+      </fix>
+      <update>
+        <bug>61057</bug>: Update to Eclipse JDT Compiler 4.6.3. (violetagg)
+      </update>
+      <fix>
+        <bug>61065</bug>: Ensure that once the class is resolved by
+        <code>javax.el.ImportHandler#resolveClass</code> it will be cached with
+        the proper name. (violetagg)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="WebSocket">
+    <changelog>
+      <add>
+        Introduce new API <code>o.a.tomcat.websocket.WsSession#suspend</code>/
+        <code>o.a.tomcat.websocket.WsSession#resume</code> that can be used to
+        suspend/resume reading of the incoming messages. (violetagg)
+      </add>
+      <fix>
+        <bug>61003</bug>: Ensure the flags for reading/writing in
+        <code>o.a.t.websocket.AsyncChannelWrapperSecure</code> are correctly
+        reset even if some exceptions occurred during processing. (markt/violetagg)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Web Applications">
+    <changelog>
+      <add>
+        Add documents for <code>maxIdleTime</code> attribute to Channel Receiver
+        docs. (kfujino)
+      </add>
+    </changelog>
+  </subsection>
+  <subsection name="Tribes">
+    <changelog>
+      <add>
+        Add features to get the statistics of the thread pool of the
+        <code>Receiver</code> component and
+        <code>MessageDispatchInterceptor</code>. These statistics information
+        can be acquired via JMX. (kfujino)
+      </add>
+      <add>
+        Add <code>maxIdleTime</code> attribute to <code>NioReceiverMBean</code>
+        in order to expose to JMX. (kfujino)
+      </add>
+      <add>
+        Add JMX support for <code>Channel Interceptors</code>. The Interceptors
+        that implement JMX support are <code>TcpFailureDetector</code>,
+        <code>ThroughputInterceptor</code>, <code>TcpPingInterceptor</code>,
+        <code>StaticMembershipInterceptor</code>,
+        <code>MessageDispatchInterceptor</code> and
+        <code>DomainFilterInterceptor</code>. (kfujino)
+      </add>
+    </changelog>
+  </subsection>
+  <subsection name="Other">
+    <changelog>
+      <add>
+        Modify the Ant build script used to publish to a Maven repository so
+        that it no longer requires artifacts to be GPG signed. This is make it
+        possible for the CI system to upload snapshot builds to the ASF Maven
+        repository. (markt)
+      </add>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.0.M20 (markt)" rtext="2017-04-18">
+  <subsection name="Catalina">
+    <changelog>
+      <update>
+        Update the Servlet 4.0 API implementation to reflect the change in
+        method name from <code>getPushBuilder()</code> to
+        <code>newPushBuilder()</code>. (markt)
+      </update>
+      <fix>
+        Correct various edge cases in the new HTTP Host header validation
+        parser. Patch provided by Katya Todorova. (martk)
+      </fix>
+      <fix>
+        Correct a regression in the X to comma refactoring that broke JMX
+        operations that take parameters. (markt)
+      </fix>
+      <fix>
+        Avoid a <code>NullPointerException</code> when reading attributes for a
+        running HTTP connector where TLS is not enabled. (markt)
+      </fix>
+      <fix>
+        <bug>47214</bug>: Refactor code so that explicitly referenced inner
+        classes are given explicit names rather than being anonymous. (markt)
+      </fix>
+      <fix>
+        <bug>59825</bug>: Log a message that lists the components in the
+        processing chain that do not support async processing when a call to
+        <code>ServletRequest.startAsync()</code> fails. (markt)
+      </fix>
+      <fix>
+        <bug>60940</bug>: Improve the handling of the <code>META-INF/</code> and
+        <code>META-INF/MANIFEST.MF</code> entries for Jar files located in
+        <code>/WEB-INF/lib</code> when running a web application from a packed
+        WAR file. (markt)
+      </fix>
+      <fix>
+        Pre-load the <code>ExceptionUtils</code> class. Since the class is used
+        extensively in error handling, it is prudent to pre-load it to avoid any
+        failure to load this class masking the true problem during error
+        handling. (markt)
+      </fix>
+      <fix>
+        Avoid potential <code>NullPointerException</code>s related to access
+        logging during shutdown, some of which have been observed when running
+        the unit tests. (markt)
+      </fix>
+      <fix>
+        When there is no <code>javax.servlet.WriteListener</code> registered
+        then a call to <code>javax.servlet.ServletOutputStream#isReady</code>
+        will return <code>false</code> instead of throwing
+        <code>IllegalStateException</code>. (violetagg)
+      </fix>
+      <fix>
+        When there is no <code>javax.servlet.ReadListener</code> registered
+        then a call to <code>javax.servlet.ServletInputStream#isReady</code>
+        will return <code>false</code> instead of throwing
+        <code>IllegalStateException</code>. (violetagg)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Coyote">
+    <changelog>
+      <fix>
+        Align cipher configuration parsing with current OpenSSL master. (markt)
+      </fix>
+      <fix>
+        <bug>60970</bug>: Fix infinite loop if application tries to write a
+        large header to the response when using HTTP/2. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Jasper">
+    <changelog>
+      <fix>
+        <bug>47214</bug>: Refactor code so that explicitly referenced inner
+        classes are given explicit names rather than being anonymous. (markt)
+      </fix>
+      <fix>
+        <bug>60925</bug>: Improve the handling of access to properties defined
+        by interfaces when a <code>BeanELResolver</code> is used under a
+        <code>SecurityManager</code>. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Tribes">
+    <changelog>
+      <add>
+        Add JMX support for Tribes components. (kfujino)
+      </add>
+    </changelog>
+  </subsection>
+  <subsection name="jdbc-pool">
+    <changelog>
+      <scode>
+        Refactor the creating a constructor for a proxy class to reduce
+        duplicate code. (kfujino)
+      </scode>
+      <fix>
+        In <code>StatementFacade</code>, the method call on the statements that
+        have been closed throw <code>SQLException</code> rather than
+        <code>NullPointerException</code>. (kfujino)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Other">
+    <changelog>
+      <fix>
+        <bug>60932</bug>: Correctly escape single quotes when used in i18n
+        messages. Based on a patch by Michael Osipov. (markt)
+      </fix>
+      <scode>
+        Review i18n property files, remove unnecessary escaping and consistently
+        use <code>[...]</code> to delimit inserted values. (markt)
+      </scode>
+      <fix>
+        Update the custom Ant task that integrates with the Symantec code
+        signing service to use the now mandatory 2-factor authentication.
+        (markt)
+      </fix>
+      <scode>
+        Refactoring in preparation for Java 9. Refactor to avoid using some
+        methods that will be deprecated in Java 9 onwards. (markt)
+      </scode>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.0.M19 (markt)" rtext="2017-03-30">
+  <subsection name="Catalina">
+    <changelog>
+      <add>
+        <bug>54618</bug>: Add support to the
+        <code>HttpHeaderSecurityFilter</code> for the HSTS preload parameter.
+        (markt)
+      </add>
+      <fix>
+        Correct a bug in the implementation of the Servlet 4.0 feature that
+        allows specifying a default request and/or response character encoding
+        per web application. <code>null</code> values passed via the
+        programmatic interface no longer trigger a
+        <code>NullPointerException</code>. (markt)
+      </fix>
+      <fix>
+        Correct a potential exception during shutdown when one or more
+        Containers are configured with a value of 1 for startStopThreads.
+        (markt)
+      </fix>
+      <fix>
+        <bug>60853</bug>: Expose the <code>SSLHostConfig</code> and
+        <code>SSLHostConfigCertificate</code> objects via JMX. (markt)
+      </fix>
+      <fix>
+        <bug>60876</bug>: Ensure that <code>Set-Cookie</code> headers generated
+        by the <code>Rfc6265CookieProcessor</code> are aligned with the
+        specification. Patch provided by Jim Griswold. (markt)
+      </fix>
+      <fix>
+        <bug>60882</bug>: Fix a <code>NullPointerException</code> when obtaining
+        a <code>RequestDispatcher</code> for a request that will not have any
+        pathInfo associated with it. This was a regression in the changes in
+        9.0.0.M18 for the Servlet 4.0 API changes. (markt)
+      </fix>
+      <update>
+        Align <code>PushBuilder</code> API with changes from the Servlet expert
+        group. (markt)
+      </update>
+      <update>
+        Align web.xml parsing rules with changes from the Servlet expert group
+        for <code>&lt;request-character-encoding&gt;</code> and
+        <code>&lt;response-character-encoding&gt;</code>. (markt)
+      </update>
+      <scode>
+        Refactor the various implementations of X to comma separated list to a
+        single utility class and update the code to use the new utility class.
+        (markt)
+      </scode>
+      <fix>
+        <bug>60911</bug>: Ensure NPE will not be thrown when looking for SSL
+        session ID. Based on a patch by Didier Gutacker. (violetagg)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Coyote">
+    <changelog>
+      <fix>
+        Add async based IO groundwork for HTTP/2. (remm)
+      </fix>
+      <fix>
+        Fix HTTP/2 incorrect input unblocking on EOF. (remm)
+      </fix>
+      <fix>
+        Close the connection sooner if an event occurs for a current connection
+        that is not consistent with the current state of that connection.
+        (markt)
+      </fix>
+      <fix>
+        Speed up shutdown when using multiple acceptor threads by ensuring that
+        the code that unlocks the acceptor threads correctly handles the case
+        where there are multiple threads. (markt)
+      </fix>
+      <fix>
+        <bug>60851</bug>: Add <code>application/xml</code> and
+        <code>application/json</code> to the default list of compressible MIME
+        types. Patch by Michael Osipov. (markt)
+      </fix>
+      <fix>
+        <bug>60852</bug>: Correctly spell compressible when used in
+        configuration attributes and internal code. Based on a patch by Michael
+        Osipov. (markt)
+      </fix>
+      <fix>
+        <bug>60900</bug>: Avoid a <code>NullPointerException</code> in the APR
+        Poller if a connection is closed at the same time as new data arrives on
+        that connection. (markt)
+      </fix>
+      <fix>
+        Improve HPACK specification compliance by fixing some test failures
+        reported by the h2spec tool written by Moto Ishizawa. (markt)
+      </fix>
+      <fix>
+        Improve HTTP/2 specification compliance by fixing some test failures
+        reported by the h2spec tool written by Moto Ishizawa. (markt)
+      </fix>
+      <fix>
+        <bug>60918</bug>: Fix sendfile processing error that could lead to
+        subsequent requests experiencing an <code>IllegalStateException</code>.
+        (markt)
+      </fix>
+      <fix>
+        Improve sendfile handling when requests are pipelined. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Jasper">
+    <changelog>
+      <fix>
+        <bug>60844</bug>: Correctly handle the error when fewer parameter values
+        than required by the method are used to invoke an EL method expression.
+        Patch provided by Daniel Gray. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="jdbc-pool">
+    <changelog>
+      <fix>
+        <bug>60764</bug>: Implement <code>equals()</code> and
+        <code>hashCode()</code> in the <code>StatementFacade</code> in order to
+        enable these methods to be called on the closed statements if any
+        statement proxy is set. This behavior can be changed with
+        <code>useStatementFacade</code> attribute. (kfujino)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Other">
+    <changelog>
+      <fix>
+        Refactor the build script and the NSIS installer script so that either
+        NSIS 2.x or NSIS 3.x can be used to build the installer. This is
+        primarily to re-enable building the installer on the Linux based CI
+        system where the combination of NSIS 3.x and wine leads to failed
+        installer builds. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.0.M18 (markt)" rtext="2017-03-13">
+  <subsection name="Catalina">
+    <changelog>
+      <fix>
+        <bug>60469</bug>: Refactor <code>RealmBase</code> for better code re-use
+        when implementing Realms that use a custom <code>Principal</code>.
+        (markt)
+      </fix>
+      <fix>
+        <bug>60490</bug>: Various formatting and layout improvements for the
+        <code>ErrorReportValve</code>. Patch provided by Michael Osipov. (markt)
+      </fix>
+      <fix>
+        <bug>60573</bug>: Remove the reason phrase when sending a
+        <code>100</code> response status for consistency with other response
+        status lines. Patch provided by Michael Osipov. (markt)
+      </fix>
+      <update>
+        <bug>60596</bug>: Improve performance of DefaultServlet when sendfile
+        feature is disabled on connector. (kkolinko)
+      </update>
+      <scode>
+        Make it easier for sub-classes of <code>Tomcat</code> to modify the
+        default web.xml settings by over-riding
+        <code>getDefaultWebXmlListener()</code>. Patch provided by Aaron
+        Anderson. (markt)
+      </scode>
+      <fix>
+        Reduce the contention in the default <code>InstanceManager</code>
+        implementation when multiple threads are managing objects and need to
+        reference the annotation cache. (markt)
+      </fix>
+      <fix>
+        <bug>60623</bug>: When startStopThreads is 1 (or a special value that
+        is equivalent to 1) then rather than using an
+        <code>ExecutorService</code> to start the children of the current
+        component, the children will be started on the current thread. (markt)
+      </fix>
+      <scode>
+        <bug>60674</bug>: Remove <code>final</code> marker from
+        <code>CorsFilter</code> to enable sub-classing. (markt)
+      </scode>
+      <fix>
+        <bug>60683</bug>: Security manager failure causing NPEs when doing IO
+        on some JVMs. (csutherl)
+      </fix>
+      <fix>
+        <bug>60688</bug>: Update the internal fork of Apache Commons BCEL to
+        r1782855 to add early access Java 9 support to the annotation scanning
+        code. (markt)
+      </fix>
+      <fix>
+        <bug>60694</bug>: Prevent NPE during authentication when no JASPIC
+        <code>AuthConfigFactory</code> is available. (markt)
+      </fix>
+      <fix>
+        <bug>60697</bug>: When HTTP TRACE requests are disabled on the
+        Connector, ensure that the HTTP OPTIONS response from custom servlets
+        does not include TRACE in the returned Allow header. (markt)
+      </fix>
+      <fix>
+        <bug>60718</bug>: Improve error handling for asynchronous processing and
+        correct a number of cases where the <code>requestDestroyed()</code>
+        event was not being fired and an entry wasn't being made in the access
+        logs. (markt)
+      </fix>
+      <fix>
+        <bug>60720</bug>: Replace "WWW-Authenticate" literal with static final
+        AUTH_HEADER_NAME in SpnegoAuthenticator. Patch provided by Michael
+        Osipov. (violetagg)
+      </fix>
+      <fix>
+        The default JASPIC <code>AuthConfigFactory</code> now correctly notifies
+        registered <code>RegistrationListener</code>s when a new
+        <code>AuthConfigProvider</code> is registered. (markt)
+      </fix>
+      <scode>
+        Improve the performance of <code>AuthenticatorBase</code> when there is
+        no JASPIC configuration available. (violetagg)
+      </scode>
+      <fix>
+        When HTTP TRACE requests are disabled on the Connector, ensure that the
+        HTTP OPTIONS response from the WebDAV servlet does not include
+        TRACE in the returned Allow header. (markt)
+      </fix>
+      <fix>
+        <bug>60722</bug>: Take account of the
+        <strong>dispatchersUseEncodedPaths</strong> setting on the current
+        <strong>Context</strong> when generating paths for dispatches triggered
+        by <code>AsyncContext.dispatch()</code>. (markt)
+      </fix>
+      <fix>
+        <bug>60728</bug>: Make the separator Tomcat uses in the Tomcat specific
+        <code>war:file:...</code> URL protocol customizable via a system
+        property. The separator is equivalent to the use of the <code>!</code>
+        character in <code>jar:file:...</code> URLs. The default separator of
+        <code>*</code> remains unchanged. (markt)
+      </fix>
+      <update>
+        Update the Servlet 4.0 API implementation to align with the latest
+        proposals from the Servlet 4.0 expert group. This includes updates to
+        the new Servlet mapping API, new methods on the
+        <code>ServletContext</code> to make the available API more equivalent to
+        the deployment descriptor, updates to the HTTP push API and the ability
+        to set default request and response character encoding per web
+        application. Note that the Servlet 4.0 API is still a work in progress
+        and further changes are likely. (markt)
+      </update>
+      <fix>
+        <bug>60798</bug>: Correct a bug in the handling of JARs in unpacked WARs
+        that meant multiple attempts to read the same entry from a JAR in
+        succession would fail for the second and subsequent attempts. (markt)
+      </fix>
+      <fix>
+        <bug>60808</bug>: Ensure that the <code>Map</code> returned by
+        <code>ServletRequest.getParameterMap()</code> is fully immutable. Based
+        on a patch provided by woosan. (markt)
+      </fix>
+      <fix>
+        <bug>60824</bug>: Correctly cache the <code>Subject</code> in the
+        session - if there is a session - when running under a
+        <code>SecurityManager</code>. Patch provided by Jan Engehausen. (markt)
+      </fix>
+      <fix>
+        Ensure request and response facades are used when firing application
+        listeners. (markt/remm)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Coyote">
+    <changelog>
+      <fix>
+        Improve handling of case when an HTTP/2 client sends more data that is
+        subject to flow control than the current window size allows. (markt)
+      </fix>
+      <fix>
+        Improve NIO2 look-ahead parsing of TLS client hello for SNI with large
+        client hello messages. (markt)
+      </fix>
+      <add>
+        Enable ALPN and also, therefore, HTTP/2 for the NIO and NIO2 HTTP
+        connectors when using the JSSE implementation for TLS when running on
+        Java 9. (markt)
+      </add>
+      <fix>
+        Restore Java 9 direct byte buffer compatibility. (remm)
+      </fix>
+      <fix>
+        <bug>59807</bug>: Provide a better error message when there is no
+        <strong>SSLHostConfig</strong> defined with a <code>hostName</code> that
+        matches the <code>defaultSSLHostConfigName</code> for the associated
+        <strong>Connector</strong>. (markt)
+      </fix>
+      <fix>
+        <bug>60627</bug>: Modify the <code>Rfc6265CookieProcessor</code> so that
+        in addition to cookie headers that start with an explicit RFC 2109
+        <code>$Version=1</code>, cookies that start with <code>$Version=0</code>
+        are also parsed as RFC 2109 cookies. (markt)
+      </fix>
+      <fix>
+        Include the value of <code>SslHostConfig.truststoreAlgorithm</code> when
+        warning that the algorithm does not support the
+        <code>certificateVerificationDepth</code> configuration option. (markt)
+      </fix>
+      <fix>
+        Ensure that executor thread pools used with connectors pre-start the
+        configured minimum number of idle threads. (markt)
+      </fix>
+      <fix>
+        <bug>60716</bug>: Add a new JSSE specific attribute,
+        <code>revocationEnabled</code>, to <code>SSLHostConfig</code> to permit
+        JSSE provider revocation checks to be enabled when no
+        <code>certificateRevocationListFile</code> has been configured. The
+        expectation is that configuration will be performed via a JSSE provider
+        specific mechanisms. (markt)
+      </fix>
+      <fix>
+        Modify the cookie header generated by the
+        <code>Rfc6265CookieProcessor</code> so it always sends an
+        <code>Expires</code> attribute as well as a <code>Max-Age</code>
+        attribute to avoid problems with Microsoft browsers that do not support
+        the <code>Max-Age</code> attribute. (markt)
+      </fix>
+      <fix>
+        <bug>60761</bug>: Expose a protected getter and setter for
+        <code>NioEndpoint.stopLatch</code> to make the class easier to extend.
+        (markt)
+      </fix>
+      <fix>
+        Prevent blocking reads after a stream exception occurs with HTTP/2.
+        (remm)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Jasper">
+    <changelog>
+      <fix>
+        Follow up to the fix for <bug>58178</bug>. When creating the
+        <code>ELContext</code> for a tag file, ensure that any registered
+        <code>ELContextListener</code>s are fired. (markt)
+      </fix>
+      <fix>
+        Refactor code generated for JSPs to reduce the size of the code required
+        for tags. (markt)
+      </fix>
+      <fix>
+        Improve the error handling for simple tags to ensure that the tag is
+        released and destroyed once used. (remm, violetagg)
+      </fix>
+      <fix>
+        <bug>60769</bug>: Correct a regression in the XML encoding detection
+        refactoring carried out for 9.0.0.M16 that incorrectly always used the
+        detected BOM encoding in preference to any encoding specified in the
+        prolog. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Cluster">
+    <changelog>
+      <add>
+        Make the <code>accessTimeout</code> configurable in
+        <code>BackupManager</code> and <code>ClusterSingleSignOn</code>. The
+        <code>accessTimeout</code> is used as a timeout period for PING in
+        replication map. (kfujino)
+      </add>
+      <fix>
+        <bug>60806</bug>: To avoid <code>ClassNotFoundException</code>, make
+        sure that the web application class loader is passed to
+        <code>ReplicatedContext</code>. (kfujino)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="WebSocket">
+    <changelog>
+      <fix>
+        <bug>60617</bug>: Correctly create a <code>CONNECT</code> request when
+        establishing a WebSocket connection via a proxy. Patch provided by
+        Svetlin Zarev. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Tribes">
+    <changelog>
+      <add>
+        Add log message that PING message has received beyond the timeout
+        period. (kfujino)
+      </add>
+      <fix>
+        When a PING message that beyond the time-out period has been received,
+        make sure that valid member is added to the map membership. (kfujino)
+      </fix>
+      <fix>
+        Ensure that <code>NoRpcChannelReply</code> messages are not received on
+        <code>RpcCallback</code>. (kfujino)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Web Applications">
+    <changelog>
+      <fix>
+        Add Specification and Javadoc references for JASPIC to the Docs
+        application. (csutherl)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Other">
+    <changelog>
+      <fix>
+        Spelling corrections provided by Josh Soref. (violetagg)
+      </fix>
+      <scode>
+        Remove local definition of web service annotations since these are
+        provided by the JRE. (markt)
+      </scode>
+      <update>
+        Update the packaged version of the Tomcat Native Library to 1.2.12 to
+        pick up the latest Windows binaries built with OpenSSL 1.0.2k. (violetagg)
+      </update>
+      <add>
+        <bug>60784</bug>: Update all unit tests that test the HTTP status line
+        to check for the required space after the status code. Patch provided by
+        Michael Osipov. (markt)
+      </add>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.0.M17 (markt)" rtext="2017-01-16">
+  <subsection name="Catalina">
+    <changelog>
+      <add>
+        <bug>60620</bug>:
+        Extend the <code>JreMemoryLeakPreventionListener</code> to provide
+        protection against <code>ForkJoinPool.commonPool()</code> related memory
+        leaks. (markt)
+      </add>
+    </changelog>
+  </subsection>
+  <subsection name="Coyote">
+    <changelog>
+      <fix>
+        Ensure UpgradeProcessor instances associated with closed connections are
+        removed from the map of current connections to Processors. (markt)
+      </fix>
+      <fix>
+        Remove a workaround for a problem previously reported with WebSocket,
+        TLS and APR that treated some error conditions as not errors. The
+        original problem cannot be reproduced with the current code and the
+        work-around is now causing problems. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Jasper">
+    <changelog>
+      <fix>
+        <bug>60497</bug>: Follow up fix using a better variable name for the
+        tag reuse flag. (remm)
+      </fix>
+      <fix>
+        Revert use of try/finally for simple tags. (remm)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="WebSocket">
+    <changelog>
+      <fix>
+        Prevent potential processing loop on unexpected WebSocket connection
+        closure. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="jdbc-pool">
+    <changelog>
+      <add>
+        Enable reset the statistics without restarting the pool. (kfujino)
+      </add>
+    </changelog>
+  </subsection>
+  <subsection name="Other">
+    <changelog>
+      <update>
+        Update the NSIS Installer used to build the Windows installer to version
+        3.01. (markt)
+      </update>
+      <fix>
+        Spelling corrections provided by Josh Soref. (violetagg)
+      </fix>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.0.M16 (markt)" rtext="not released">
+  <subsection name="Catalina">
+    <changelog>
+      <add>
+        <bug>53602</bug>: Add HTTP status code 451 (RFC 7725) to the list of
+        HTTP status codes recognised by the ErrorReportValve. (markt)
+      </add>
+      <fix>
+        <bug>60446</bug>: Handle the case where the stored user credential uses
+        a different key length than the length currently configured for the
+        <code>CredentialHandler</code>. Based on a patch by Niklas Holm. (markt)
+      </fix>
+      <update>
+        Update the warnings that reference required options for running on Java
+        9 to use the latest syntax for those options. (markt)
+      </update>
+      <fix>
+        <bug>60513</bug>: Fix thread safety issue with RMI cleanup code. (remm)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Coyote">
+    <changelog>
+      <fix>
+        Expand the search process for a server certificate when OpenSSL is used
+        with a JSSE connector and an explicit alias has not been configured.
+        (markt)
+      </fix>
+      <scode>
+        Extract the common Acceptor code from each Endpoint into a new Acceptor
+        class that is used by all Endpoints. (markt)
+      </scode>
+      <fix>
+        <bug>60450</bug>: Improve the selection algorithm for the default trust
+        store type for a TLS Virtual Host. In particular, don't use
+        <code>PKCS12</code> as a default trust store type. Better document how
+        the default trust store type is selected for a TLS virtual host. (markt)
+      </fix>
+      <fix>
+        <bug>60451</bug>: Correctly handle HTTP/2 header values that contain
+        characters with unicode code points in the range 128 to 255. Reject
+        with a clear error message HTTP/2 header values that contain characters
+        with unicode code points above 255. (markt)
+      </fix>
+      <fix>
+        Improve the logic that selects an address to use to unlock the Acceptor
+        to take account of platforms what do not listen on all local addresses
+        when configured with an address of <code>0.0.0.0</code> or
+        <code>::</code>. (markt)
+      </fix>
+      <fix>
+        Correct a regression in the refactoring to make wider use of
+        <code>ByteBuffer</code> that caused an intermittent failure in the unit
+        tests. (markt)
+      </fix>
+      <fix>
+        <bug>60482</bug>: HTTP/2 shouldn't do URL decoding on the query string.
+        (remm)
+      </fix>
+      <fix>
+        Fix an HTTP/2 compression error. Once a new size has been agreed for the
+        dynamic HPACK table, the next header block must begin with a dynamic
+        table update. (markt)
+      </fix>
+      <fix>
+        <bug>60508</bug>: Set request start time for HTTP/2. (remm)
+      </fix>
+      <fix>
+        The default output buffer size for AJP connectors is now based on the
+        configured AJP packet size rather than the minimum permitted AJP packet
+        size. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Jasper">
+    <changelog>
+      <update>
+        Implement a simpler JSP file encoding detector that delegates XML prolog
+        encoding detection to the JRE rather than using a custom XML parser.
+        (markt)
+      </update>
+      <fix>
+        <bug>60497</bug>: Restore previous tag reuse behavior following the use
+        of try/finally. (remm)
+      </fix>
+      <fix>
+        Improve the error handling for simple tags to ensure that the tag is
+        released and destroyed once used. (remm)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="WebSocket">
+    <changelog>
+      <fix>
+        Correctly handle blocking WebSocket writes when the write times out just
+        before the write is attempted. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Web Applications">
+    <changelog>
+      <fix>
+        <bug>60344</bug>: Add a note to BUILDING.txt regarding using the source
+        bundle with the correct line endings. (markt)
+      </fix>
+      <fix>
+        <bug>60467</bug>: remove problematic characters from XML documentation.
+        Based upon a patch by Michael Osipov. (schultz)
+      </fix>
+      <add>
+        In the documentation web application, be explicit that clustering
+        requires a secure network for all of the cluster network traffic.
+        (markt)
+      </add>
+      <update>
+        Update the ASF logos to the new versions.
+      </update>
+      <fix>
+        <bug>60468</bug>: Correct the format of the sample ISO-8601 date used
+        to report the build date for the documentation. Patch provided by
+        Michael Osipov. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Other">
+    <changelog>
+      <update>
+        Update the ASF logos used in the Apache Tomcat installer for Windows to
+        use the new versions.
+      </update>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.0.M15 (markt)" rtext="2016-12-08">
+  <subsection name="Other">
+    <changelog>
+      <scode>
+        Increment version due a local build configuration error with 9.0.0.M14
+        that wasn't caught until after digital signing had been completed
+        Signing requires unique names so a new tag was required. (markt)
+      </scode>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.0.M14 (markt)" rtext="not released">
+  <subsection name="Catalina">
+    <changelog>
+      <update>
+        <bug>60202</bug>: Add an available flag to realms, to indicate the
+        state, or the realm backend. Update lockout realm to only register
+        auth failures if the realm is available. (remm)
+      </update>
+      <fix>
+        <bug>60340</bug>: Readability improvements for CSS used in
+        DefaultServlet and ErrorReportValve. Patch provided by Michael
+        Osipov. (violetagg)
+      </fix>
+      <fix>
+        <bug>60351</bug>: Delay creating <code>META-INF/war-tracker</code> file
+        until after the WAR has been expanded to address the case where the
+        Tomcat process terminates during the expansion. (markt)
+      </fix>
+      <fix>
+        Correctly generate URLs for resources located inside JARs that are
+        themselves located inside a packed WAR file. (markt)
+      </fix>
+      <fix>
+        Correctly handle the <code>configClass</code> attribute of a Host when
+        embedding Tomcat. (markt)
+      </fix>
+      <update>
+        <bug>60368</bug>: Stop creating a default connector on start in
+        embedded mode. (remm)
+      </update>
+      <fix>
+        <bug>60379</bug>: Dispose of the GSS credential once it is no longer
+        required. Patch provided by Michael Osipov. (markt)
+      </fix>
+      <fix>
+        <bug>60380</bug>: Ensure that a call to
+        <code>HttpServletRequest#logout()</code> triggers a call to
+        <code>TomcatPrincipal#logout()</code>. Based on a patch by Michael
+        Osipov. (markt)
+      </fix>
+      <fix>
+        <bug>60381</bug>: Provide a standard <code>toString()</code>
+        implementation for components that implement <code>Contained</code>.
+        (markt)
+      </fix>
+      <fix>
+        <bug>60387</bug>: Correct the javadoc for
+        <code>o.a.catalina.AccessLog.setRequestAttributesEnabled</code>.
+        The default value is different for the different implementations.
+        (violetagg)
+      </fix>
+      <scode>
+        <bug>60393</bug>: Use consistent parameter naming in implementations of
+        <code>Realm#authenticate(GSSContext, boolean)</code>. (markt)
+      </scode>
+      <scode>
+        Refactor the <code>org.apache.naming</code> package to reduce duplicate
+        code. Duplicate code identified by the Simian tool. (markt)
+      </scode>
+      <scode>
+        Refactor the implementations of
+        <code>HttpServletRequest#getRequestURL()</code> to reduce duplicate
+        code. Duplicate code identified by the Simian tool. (markt)
+      </scode>
+      <scode>
+        Refactor Catalina interfaces to make wider use of the
+        <code>Contained</code> interface and reduce duplication. (markt)
+      </scode>
+      <scode>
+        Remove the <code>getName()</code> method from <code>RealmBase</code>
+        along with the various constants used by the sub-classes to store the
+        return value. (markt)
+      </scode>
+      <fix>
+        <bug>60395</bug>: Log when an <code>Authenticator</code> passes an
+        incomplete <code>GSSContext</code> to a Realm since it indicates a bug
+        in the <code>Authenticator</code>. Patch provided by Michael Osipov.
+        (markt)
+      </fix>
+      <fix>
+        <bug>60400</bug>: When expanding the buffer used for reading the
+        request body, ensure the read position will be restored to the
+        original one. (violetagg)
+      </fix>
+      <scode>
+        Refactor the MBean implementations for the internal Tomcat components
+        to reduce code duplication. (markt)
+      </scode>
+      <fix>
+        <bug>60410</bug>: Ensure that multiple calls to
+        <code>JarInputStreamWrapper#close()</code> do not incorrectly trigger
+        the closure of the underlying JAR or WAR file. (markt)
+      </fix>
+      <fix>
+        <bug>60411</bug>: Implement support in the <code>RewriteValve</code> for
+        symbolic names to specify the redirect code to use when returning a
+        redirect response to the user agent. Patch provided by Michael Osipov.
+        (markt)
+      </fix>
+      <fix>
+        <bug>60413</bug>: In the <code>RewriteValve</code> write empty capture
+        groups as the empty string rather than as <code>&quot;null&quot;</code>
+        when generating the re-written URL. Based on a patch by Michael Osipov.
+        (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Coyote">
+    <changelog>
+      <fix>
+        <bug>60372</bug>: Ensure the response headers' buffer limit is reset to
+        the capacity of this buffer when IOException occurs while writing the
+        headers to the socket. (violetagg)
+      </fix>
+      <fix>
+        Ensure that the availability of configured upgrade protocols that
+        require ALPN is correctly reported during Tomcat start. (markt)
+      </fix>
+      <fix>
+        <bug>60386</bug>: Implement a more sophisticated pruning algorithm for
+        removing closed streams from the priority tree to ensure that the tree
+        does not grow too large. (markt)
+      </fix>
+      <fix>
+        <bug>60409</bug>: When unable to complete sendfile request, ensure the
+        Processor will be added to the cache only once. (markt/violetagg)
+      </fix>
+      <fix>
+        Ensure that the endpoint is able to unlock the acceptor thread during
+        shutdown if the endpoint is configured to listen to any local address
+        of a specific type such as <code>0.0.0.0</code> or <code>::</code>.
+        (markt)
+      </fix>
+      <add>
+        Add a new configuration option, <code>ipv6v6only</code> to the APR
+        connectors that allows them to be configure to only accept IPv6
+        connections when configured with an IPv6 address rather than the
+        default which is to accept IPv4 connections as well if the operating
+        system uses a dual network stack. (markt)
+      </add>
+      <fix>
+        Improve the logic that unlocks the acceptor thread so a better choice is
+        made for the address to connect to when a connector is configured for
+        any local port. This reduces the likelihood of the unlock failing.
+        (markt)
+      </fix>
+      <fix>
+        <bug>60436</bug>: Avoid a potential NPE when processing async timeouts.
+        (markt)
+      </fix>
+      <fix>
+        Reduce the window in which an async request that has just started
+        processing on a container thread remains eligible for an async timeout.
+        (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Jasper">
+    <changelog>
+      <fix>
+        <bug>60431</bug>: Improve handling of varargs in UEL expressions. Based
+        on a patch by Ben Wolfe. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Web applications">
+    <changelog>
+      <fix>
+        Correct a typo in Host Configuration Reference.
+        Issue reported via comments.apache.org. (violetagg)
+      </fix>
+      <fix>
+        <bug>60412</bug>: Add information on the comment syntax for the
+        <code>RewriteValve</code> configuration. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Tribes">
+    <changelog>
+      <fix>
+        Reduce the warning logs for a message received from a different domain
+        in order to avoid excessive log outputs. (kfujino)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="WebSocket">
+    <changelog>
+      <fix>
+        <bug>60437</bug>: Avoid possible handshake overflows in the websocket
+        client. (remm)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="jdbc-pool">
+    <changelog>
+      <add>
+        <bug>58816</bug>: Implement the statistics of jdbc-pool. The stats infos
+        are <code>borrowedCount</code>, <code>returnedCount</code>,
+        <code>createdCount</code>, <code>releasedCount</code>,
+        <code>reconnectedCount</code>, <code>releasedIdleCount</code> and
+        <code>removeAbandonedCount</code>. (kfujino)
+      </add>
+      <fix>
+        <bug>60194</bug>: If <code>validationQuery</code> is not specified,
+        connection validation is done by calling the <code>isValid()</code>
+        method. (kfujino)
+      </fix>
+      <fix>
+        <bug>60398</bug>: Fix testcase of <code>TestSlowQueryReport</code>.
+        (kfujino)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Other">
+    <changelog>
+      <fix>
+        Allow customization of service.bat, such as heap memory size, service
+        startup mode and JVM args. Patch provided by isapir via Github.
+        (violetagg)
+      </fix>
+      <fix>
+        <bug>60366</bug>: Change <code>catalina.bat</code> to use directly
+        <code>LOGGING_MANAGER</code> and <code>LOGGING_CONFIG</code> variables
+        in order to configure logging, instead of modifying
+        <code>JAVA_OPTS</code>. Patch provided by Petter Isberg. (violetagg)
+      </fix>
+      <fix>
+        <bug>60383</bug>: JASPIC API is added as a dependency to the
+        <code>org.apache.tomcat:tomcat-catalina</code> maven artifact.
+        (violetagg)
+      </fix>
+      <fix>
+        Update the comments associated with the TLS Connector examples in
+        <code>server.xml</code>. (markt)
+      </fix>
+      <add>
+        New property is added <code>test.verbose</code> in order to control
+        whether the output of the tests is displayed on the console or not.
+        Patch provided by Emmanuel Bourg. (violetagg)
+      </add>
+      <scode>
+        <code>TestOpenSSLCipherConfigurationParser.testSpecification</code>
+        - if there are test failures, provide more detailed information. Patch
+        provided by Emmanuel Bourg. (violetagg)
+      </scode>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.0.M13 (markt)" rtext="2016-11-08">
+  <subsection name="Coyote">
+    <changelog>
+      <fix>
+        Check that threadPriority values used in AbstractProtocol are valid.
+        (fschumacher)
+      </fix>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.0.M12 (markt)" rtext="not released">
+  <subsection name="Catalina">
+    <changelog>
+      <fix>
+        When creating a new Connector via JMX, ensure that both HTTP/1.1 and
+        AJP/1.3 connectors can be created. (markt)
+      </fix>
+      <fix>
+        Reduce multiple error messages when Connector fails to instantiate the
+        associated ProtocolHandler. (markt)
+      </fix>
+      <fix>
+        <bug>60152</bug>: Provide an option for Connector Lifecycle exceptions
+        to be re-thrown rather than logged. This is controlled by the new
+        <code>throwOnFailure</code> attribute of the Connector. (markt)
+      </fix>
+      <fix>
+        Include the Context name in the log message when an item cannot be
+        added to the cache. (markt)
+      </fix>
+      <fix>
+        Exclude JAR files in <code>/WEB-INF/lib</code> from the static resource
+        cache. (markt)
+      </fix>
+      <fix>
+        When calling <code>getResourceAsStream()</code> on a directory, ensure
+        that <code>null</code> is returned. (markt)
+      </fix>
+      <fix>
+        <bug>60161</bug>: Allow creating subcategories of the container logger,
+        and use it for the rewrite valve. (remm)
+      </fix>
+      <fix>
+        Correctly test for control characters when reading the provided shutdown
+        password. (markt)
+      </fix>
+      <fix>
+        <bug>60297</bug>: Simplify connector creation in embedded mode. (remm)
+      </fix>
+      <fix>
+        Refactor creation of containers in embedded mode for more consistency
+        and flexibility. (remm)
+      </fix>
+      <add>
+        Log a warning if running on Java 9 with the ThreadLocal memory leak
+        detection enabled (the default) but without the command line option it
+        now requires. (markt)
+      </add>
+      <fix>
+        When a Connector is configured to use an executor, ensure that the
+        StoreConfig component includes the executor name when writing the
+        Connector configuration. (markt)
+      </fix>
+      <fix>
+        When configuring the JMX remote listener, specify the allowed types for
+        the credentials. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Coyote">
+    <changelog>
+      <fix>
+        Correct the HPACK header table size configuration that transposed the
+        client and server table sizes when creating the encoder and decoder.
+        (markt)
+      </fix>
+      <scode>
+        Review HTTP/2 implementation removing unused code, reducing visibility
+        where possible and using final where appropriate. (markt)
+      </scode>
+      <fix>
+        Don't continue to process an HTTP/2 stream if it is reset during header
+        parsing. (markt)
+      </fix>
+      <fix>
+        HTTP/2 uses separate headers for each Cookie. As required by RFC 7540,
+        merge these into a single Cookie header before processing continues.
+        (markt)
+      </fix>
+      <fix>
+        Align the HTTP/2 implementation with the HTTP/1.1 implementation and
+        return a 500 response when an unhandled exception occurs during request
+        processing. (markt)
+      </fix>
+      <fix>
+        Correct the HTTP header parser so that DEL is not treated as a valid
+        token character. (markt)
+      </fix>
+      <add>
+        Add checks around the handling of HTTP/2 pseudo headers. (markt)
+      </add>
+      <add>
+        Add support for trailer headers to the HTTP/2 implementation. (markt)
+      </add>
+      <fix>
+        <bug>60232</bug>: When processing headers for an HTTP/2 stream, ensure
+        that the read buffer is large enough for the header being processed.
+        (markt)
+      </fix>
+      <add>
+        Add configuration options to the HTTP/2 implementation to control the
+        maximum number of headers allowed, the maximum size of headers allowed,
+        the maximum number of trailer headers allowed, the maximum size of
+        trailer headers allowed and the maximum number of cookies allowed.
+        (markt)
+      </add>
+      <fix>
+        Correctly differentiate between sending and receiving a reset frame when
+        tracking the state of an HTTP/2 stream. (markt)
+      </fix>
+      <scode>
+        Remove the undocumented support for using the old Connector attribute
+        names <code>backlog</code>, <code>soLinger</code> and
+        <code>soTimeout</code> that were renamed several major versions ago.
+        (markt)
+      </scode>
+      <fix>
+        <bug>60319</bug>: When using an Executor, disconnect it from the
+        Connector attributes <code>maxThreads</code>,
+        <code>minSpareThreads</code> and <code>threadPriority</code> to enable
+        the configuration settings to be consistently reported. These Connector
+        attributes will be reported as <code>-1</code> when an Executor is in
+        use. The values used by the executor may be set and obtained via the
+        Executor. (markt)
+      </fix>
+      <fix>
+        If an I/O error occurs during async processing on a non-container
+        thread, ensure that the <code>onError()</code> event is triggered.
+        (markt)
+      </fix>
+      <fix>
+        Improve detection of I/O errors during async processing on non-container
+        threads and trigger async error handling when they are detected. (markt)
+      </fix>
+      <add>
+        Add additional checks for valid characters to the HTTP request line
+        parsing so invalid request lines are rejected sooner. (markt)
+      </add>
+    </changelog>
+  </subsection>
+  <subsection name="Jasper">
+    <changelog>
+      <update>
+        Update to the Eclipse JDT Compiler 4.6.1. (markt)
+      </update>
+    </changelog>
+  </subsection>
+  <subsection name="Web applications">
+    <changelog>
+      <add>
+        Add HTTP/2 configuration information to the documentation web
+        application. (markt)
+      </add>
+      <fix>
+        Fix default value of <code>validationInterval</code> attribute in
+        jdbc-pool. (kfujino)
+      </fix>
+      <fix>
+        Correct a typo in CGI How-To.
+        Issue reported via comments.apache.org. (violetagg)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Tribes">
+    <changelog>
+      <fix>
+        When the proxy node sends a backup retrieve message, ensure that using
+        the <code>channelSendOptions</code> that has been set rather than the
+        default <code>channelSendOptions</code>. (kfujino)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Other">
+    <changelog>
+      <add>
+        Add the JASPIC API jar to the Maven Central publication script. (markt)
+      </add>
+      <fix>
+        Remove classes from tomcat-util-scan.jar that are duplicates of those in
+        tomcat-util.jar. (markt)
+      </fix>
+      <add>
+        Update the NSIS Installer used to build the Windows installer to version
+        3.0. (markt)
+      </add>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.0.M11 (markt)" rtext="2016-10-10">
+  <subsection name="Catalina">
+    <changelog>
+      <add>
+        <bug>59961</bug>: Add an option to the <code>StandardJarScanner</code>
+        to control whether or not JAR Manifests are scanned for additional
+        class path entries. (markt)
+      </add>
+      <fix>
+        <bug>60013</bug>: Refactor the previous fix to align the behaviour of
+        the Rewrite Valve with mod_rewrite. As part of this, provide an
+        implementation for the <code>B</code> and <code>NE</code> flags and
+        improve the handling for the <code>QSA</code> flag. Includes multiple
+        test cases by Santhana Preethiand a patch by Tiago Oliveira. (markt)
+      </fix>
+      <fix>
+        <bug>60087</bug>: Refactor the web resources handling to use the Tomcat
+        specific <code>war:file:...</code> URL protocol to refer to WAR files
+        and their contents rather than the standard <code>jar:file:...</code>
+        form since some components of the JRE, such as JAR verification, give
+        unexpected results when the standard form is used. A side-effect of the
+        refactoring is that when using packed WARs, it is now possible to
+        reference a WAR and/or specific JARs within a WAR in the security policy
+        file used when running under a <code>SecurityManager</code>. (markt)
+      </fix>
+      <fix>
+        <bug>60116</bug>: Fix a problem with the rewrite valve that caused back
+        references evaluated in conditions to be forced to lower case when using
+        the <code>NC</code> flag. (markt)
+      </fix>
+      <fix>
+        Ensure <code>Digester.useContextClassLoader</code> is considered in
+        case the class loader is used. (violetagg)
+      </fix>
+      <fix>
+        <bug>60117</bug>: Ensure that the name of <code>LogLevel</code> is
+        localized when using <code>OneLineFormatter</code>. Patch provided by
+        Tatsuya Bessho. (kfujino)
+      </fix>
+      <fix>
+        <bug>60138</bug>: Fix the <code>SSLHostConfig</code> so that the
+        <code>protocols</code> attribute is limited to the protocols supported
+        by the current JSSE implementation rather than the default protocols
+        used by the implementation. (markt)
+      </fix>
+      <fix>
+        <bug>60146</bug>: Improve performance for resource retrieval by making
+        calls to WebResource.getInputStream() trigger caching if the resource is
+        small enough. Patch provided by mohitchugh. (markt)
+      </fix>
+      <add>
+        <bug>60151</bug>: Improve the exception error messages when a
+        <code>ResourceLink</code> fails to specify the type, specifies an
+        unknown type or specifies the wrong type. (markt)
+      </add>
+      <fix>
+        <bug>60167</bug>: Ignore empty lines in <code>/etc/passwd</code> files
+        when using the <code>PasswdUserDatabase</code>. (markt)
+      </fix>
+      <fix>
+        <bug>60170</bug>: Exclude the compressed test file
+        <code>index.html.br</code> from RAT analysis. Patch provided by Gavin
+        McDonald. (markt)
+      </fix>
+      <fix>
+        When starting web resources, ensure that class resources are only
+        started once. (markt)
+      </fix>
+      <fix>
+        Improve the access checks for linked global resources to handle the case
+        where the current class loader is a child of the web application class
+        loader. (markt)
+      </fix>
+      <fix>
+        <bug>60196</bug>: Ensure that the <code>isMandatory</code> flag is
+        correctly set when using JASPIC authentication. (markt)
+      </fix>
+      <fix>
+        <bug>60199</bug>: Log a warning if deserialization issues prevent a
+        session attribute from being loaded. (markt)
+      </fix>
+      <fix>
+        <bug>60208</bug>: When using RFC6265 compliant cookies, the
+        <code>/</code> character should not be allowed in a cookie name since
+        the RFC6265 will drop such cookies as invalid. (markt)
+      </fix>
+      <add>
+        Introduce new methods <code>read(ByteBuffer)</code>/
+        <code>write(ByteBuffer)</code> in
+        <code>o.a.catalina.connector.CoyoteInputStream</code>/
+        <code>o.a.catalina.connector.CoyoteOutputStream</code>. (violetagg)
+      </add>
+    </changelog>
+  </subsection>
+  <subsection name="Coyote">
+    <changelog>
+      <add>
+        Refactor the code that implements the requirement that a call to
+        <code>complete()</code> or <code>dispatch()</code> made from a
+        non-container thread before the container initiated thread that called
+        <code>startAsync()</code> completes must be delayed until the container
+        initiated thread has completed. Rather than implementing this by
+        blocking the non-container thread, extend the internal state machine to
+        track this. This removes the possibility that blocking the non-container
+        thread could trigger a deadlock. (markt)
+      </add>
+      <fix>
+        Fail earlier if the client closes the connection during SNI processing.
+        (markt)
+      </fix>
+      <fix>
+        <bug>60123</bug>: Avoid potential threading issues that could cause
+        excessively large values to be returned for the processing time of
+        a current request. (markt)
+      </fix>
+      <fix>
+        <bug>60174</bug>: Log instances of <code>HeadersTooLargeException</code>
+        during request processing. (markt)
+      </fix>
+      <fix>
+        <bug>60173</bug>: Allow up to 64kB HTTP/2 header table size limit. (remm)
+      </fix>
+      <fix>
+        Java 9 compatibility of direct ByteBuffer cleaner. (remm)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Jasper">
+    <changelog>
+      <fix>
+        <bug>60101</bug>: Remove preloading of the class that was deleted.
+        (violetagg)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Web applications">
+    <changelog>
+      <add>
+        Expand the documentation for the nested elements within a
+        <code>Resources</code> element to clarify the behaviour of different
+        configuration options with respect to the order in which resources are
+        searched. (markt)
+      </add>
+      <add>
+        Add an example of using the <code>classesToInitialize</code> attribute
+        of the <code>JreMemoryLeakPreventionListener</code> to the documentation
+        web application. Based on a patch by Cris Berneburg. (markt)
+      </add>
+      <fix>
+        <bug>60192</bug>: Correct a typo in the status output of the Manager
+        application. Patch provided by  Radhakrishna Pemmasani. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="jdbc-pool">
+    <changelog>
+      <fix>
+        Notify jmx when returning the connection that has been marked suspect.
+        (kfujino)
+      </fix>
+      <fix>
+        Ensure that the <code>POOL_EMPTY</code> notification has been added to
+        the jmx notification types. (kfujino)
+      </fix>
+      <fix>
+        <bug>60099</bug>: Ensure that use all method arguments as a cache key
+        when using <code>StatementCache</code>. (kfujino)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Other">
+    <changelog>
+      <fix>
+        Update the download location for Objenesis. (violetagg)
+      </fix>
+      <fix>
+        <bug>60164</bug>: Replace <code>log4j-core*.jar</code> with
+        <code>log4j-web*.jar</code> since it is <code>log4j-web*.jar</code> that
+        contains the <code>ServletContainerInitializer</code>. (markt)
+      </fix>
+      <add>
+        Add documentation to the bin/catalina.bat script to remind users that
+        environment variables don't affect the configuration of Tomcat when
+        run as a Windows Service. Based upon a documentation patch by
+        James H.H. Lampert. (schultz)
+      </add>
+      <update>
+        Update the packaged version of the Tomcat Native Library to 1.2.10 to
+        pick up the latest Windows binaries built with OpenSSL 1.0.2j. (markt)
+      </update>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.0.M10 (markt)" rtext="2016-09-05">
+  <subsection name="Catalina">
+    <changelog>
+      <fix>
+        <bug>59813</bug>: Ensure that circular relations of the Class-Path
+        attribute from JAR manifests will be processed correctly. (violetagg)
+      </fix>
+      <fix>
+        Ensure that reading the <code>singleThreadModel</code> attribute of a
+        <code>StandardWrapper</code> via JMX does not trigger initialisation of
+        the associated servlet. With some frameworks this can trigger an
+        unexpected initialisation thread and if initialisation is not thread-safe
+        the initialisation can then fail. (markt)
+      </fix>
+      <fix>
+        Compatibility with rewrite from httpd for non existing headers.
+        (jfclere)
+      </fix>
+      <fix>
+        By default, treat paths used to obtain a request dispatcher as encoded.
+        This behaviour can be changed per web application via the
+        <code>dispatchersUseEncodedPaths</code> attribute of the Context.
+        (markt)
+      </fix>
+      <add>
+        Provide a mechanism that enables the container to check if a component
+        (typically a web application) has been granted a given permission when
+        running under a SecurityManager without the current execution stack
+        having to have passed through the component. Use this new mechanism to
+        extend SecurityManager protection to the system property replacement
+        feature of the digester. (markt)
+      </add>
+      <add>
+        When retrieving an object via a <code>ResourceLink</code>, ensure that
+        the object obtained is of the expected type. (markt)
+      </add>
+      <fix>
+        <bug>59823</bug>: Ensure that JASPIC configuration is taken into account
+        when calling <code>HttpServletRequest.authenticate()</code>. (markt)
+      </fix>
+      <fix>
+        <bug>59824</bug>: Mark the <code>RewriteValve</code> as supporting async
+        processing by default. (markt)
+      </fix>
+      <fix>
+        <bug>59839</bug>: Apply <code>roleSearchAsUser</code> to all nested
+        searches in JNDIRealm. (fschumacher)
+      </fix>
+      <fix>
+        <bug>59859</bug>: Fix resource leak in WebDAV servlet. Based on patch by
+        Coty Sutherland. (fschumacher)
+      </fix>
+      <fix>
+        <bug>59862</bug>: Allow nested jar files scanning to be filtered with
+        the system property
+        <code>tomcat.util.scan.StandardJarScanFilter.jarsToSkip</code>. Patch
+        is provided by Terence Bandoian. (violetagg)
+      </fix>
+      <fix>
+        <bug>59866</bug>: When scanning <code>WEB-INF/classes</code> for
+        annotations, don't scan the contents of
+        <code>WEB-INF/classes/META-INF</code> (if present) since classes will
+        never be loaded from that location. (markt)
+      </fix>
+      <fix>
+        <bug>59888</bug>: Correctly handle tabs and spaces in quoted version one
+        cookies when using the <code>Rfc6265CookieProcessor</code>. (markt)
+      </fix>
+      <fix>
+        A number of the JRE memory leaks addressed by the
+        <code>JreMemoryLeakPreventionListener</code> have been fixed in Java 9
+        so the associated protection is now disabled when running on Java 9
+        onwards. (markt)
+      </fix>
+      <fix>
+        <bug>59912</bug>: Fix an edge case in input stream handling where an
+        <code>IOException</code> could be thrown when reading a POST body.
+        (markt)
+      </fix>
+      <fix>
+        <bug>59913</bug>: Correct a regression introduced with the support for
+        the Servlet 4 <code>HttpServletRequest.getMapping()</code> API that
+        caused the attributes for forwarded requests to be lost if requested
+        from within a subsequent include. (markt)
+      </fix>
+      <fix>
+        <bug>59966</bug>: Do not start the web application if the error page
+        configuration in web.xml is invalid. (markt)
+      </fix>
+      <fix>
+        Switch the CGI servlet to the standard logging mechanism and remove
+        support for the debug attribute. (markt)
+      </fix>
+      <fix>
+        <bug>60012</bug>: Improvements in the log messages. Based on
+        suggestions by Nemo Chen. (violetagg)
+      </fix>
+      <fix>
+        Changes to the <code>allowLinking</code> attribute of a
+        <code>StandardRoot</code> instance now invalidate the cache if caching
+        is enabled. (markt)
+      </fix>
+      <add>
+        Add a new initialisation parameter, <code>envHttpHeaders</code>, to
+        the CGI Servlet to mitigate <a href="https://httpoxy.org">httpoxy</a>
+        (<a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-5388"
+        >CVE-2016-5388</a>) by default and to provide a mechanism that can be
+        used to mitigate any future, similar issues. (markt)
+      </add>
+      <add>
+        When adding and removing <code>ResourceLink</code>s dynamically, ensure
+        that the global resource is only visible via the
+        <code>ResourceLinkFactory</code> when it is meant to be. (markt)
+      </add>
+      <fix>
+        <bug>60008</bug>: When processing CORs requests, treat any origin with a
+        URI scheme of <code>file</code> as a valid origin. (markt)
+      </fix>
+      <fix>
+        Improve handling of exceptions during a Lifecycle events triggered by a
+        state transition. The exception is now caught and the component is now
+        placed into the <code>FAILED</code> state. (markt)
+      </fix>
+      <fix>
+        <bug>60013</bug>: Fix encoding issues when using the RewriteValve with
+        UTF-8 query strings or UTF-8 redirect URLs. (markt)
+      </fix>
+      <fix>
+        <bug>60022</bug>: Improve handling when a WAR file and/or the associated
+        exploded directory are symlinked into the <code>appBase</code>. (markt)
+      </fix>
+      <fix>
+        Fix a file descriptor leak when reading the global web.xml. (markt)
+      </fix>
+      <fix>
+        Consistently decode URL patterns provided via web.xml using the encoding
+        of the web.xml file where specified or UTF-8 where no explicit encoding
+        is specified. (markt)
+      </fix>
+      <fix>
+        Make timing attacks against the Realm implementations harder. (schultz)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Coyote">
+    <changelog>
+      <fix>
+        Correct a regression in refactoring to enable injection of custom
+        keystores that broke the automatic conversion of OpenSSL style PEM
+        key and certificate files for use with JSSE TLS connectors. (markt)
+      </fix>
+      <fix>
+        <bug>59910</bug>: Don't hardcode key alias value to "tomcat" for JSSE.
+        When using a keystore, OpenSSL will still default to it. (remm)
+      </fix>
+      <fix>
+        <bug>59904</bug>: Add a limit (default 200) for the number of cookies
+        allowed per request. Based on a patch by gehui. (markt)
+      </fix>
+      <fix>
+        <bug>59925</bug>: Correct regression in r1628368 and ensure that HTTP
+        separators are handled as configured in the
+        <code>LegacyCookieProcessor</code>. Patch provided by Kyohei Nakamura.
+        (markt)
+      </fix>
+      <fix>
+        <bug>59950</bug>: Correct log message when reporting that the current
+        number of HTTP/2 streams for a connection could not be pruned to below
+        the limit. (markt)
+      </fix>
+      <fix>
+        Ensure that <code>Semaphore.release</code> is called in all cases. Even
+        when there is an exception. (violetagg)
+      </fix>
+      <fix>
+        <bug>60030</bug>: Correct a potential infinite loop in the SNI parsing
+        code triggered by failing to handle an end of stream condition. (markt)
+      </fix>
+      <fix>
+        Refactor the JSSE client certificate validation so that the
+        effectiveness of the <code>certificateVerificationDepth</code>
+        configuration attribute does not depend on the presence of a certificate
+        revocation list. (markt)
+      </fix>
+      <fix>
+        Small logging optimization in the <code>Rfc6265CookieProcessor</code>.
+        Patch provided by Svetlin Zarev. (markt)
+      </fix>
+      <fix>
+        OpenSSL now disables 3DES by default so reflect this when using OpenSSL
+        syntax to select ciphers. (markt)
+      </fix>
+      <fix>
+        Use the proper ERROR socket status code for async errors with NIO2.
+        (remm)
+      </fix>
+      <fix>
+        <bug>60035</bug>: Fix a potential connection leak if the client drops a
+        TLS connection before the handshake completes. (markt)
+      </fix>
+      <add>
+        Log a warning at start up if a JSSE TLS connector is configured with
+        a trusted certificate that is either not yet valid or has expired.
+        (markt)
+      </add>
+    </changelog>
+  </subsection>
+  <subsection name="Jasper">
+    <changelog>
+      <fix>
+        When writing out a full web.xml file with JspC ensure that the encoding
+        used in the XML prolog matches the encoding used to write the contents
+        of the file. (markt)
+      </fix>
+      <fix>
+        Improve the error handling for custom tags to ensure that the tag is
+        returned to the pool or released and destroyed once used. (markt)
+      </fix>
+      <fix>
+        <bug>60032</bug>: Fix handling of method calls that use varargs within
+        EL value expressions. (markt)
+      </fix>
+      <fix>
+        Ignore <code>engineOptionsClass</code> and <code>scratchdir</code> when
+        running under a security manager. (markt)
+      </fix>
+      <fix>
+        Fixed StringIndexOutOfBoundsException. Based on a patch provided by
+        wuwen via Github. (violetagg)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="WebSocket">
+    <changelog>
+      <fix>
+        <bug>59908</bug>: Ensure that a reason phrase is included in the close
+        message if a session is closed due to a timeout. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Web applications">
+    <changelog>
+      <fix>
+        <bug>59867</bug>: Correct the documentation provided by Manager's
+        403.jsp. (violetagg)
+      </fix>
+      <fix>
+        <bug>59868</bug>: Clarify the documentation for the Manager web
+        application to make clearer that the host name and IP address in the
+        server section are the primary host name and IP address. (markt)
+      </fix>
+      <fix>
+        <bug>59940</bug>: Correct the name of the
+        <code>truststorePassword</code> attribute of the
+        <code>SSLHostConfig</code> element in the configuration documentation.
+        (markt)
+      </fix>
+      <fix>
+        MBeans Descriptors How-To is moved to
+        <code>mbeans-descriptors-howto.html</code>. Patch provided by Radoslav
+        Husar. (violetagg)
+      </fix>
+      <fix>
+        Update NIO Connector configuration documentation with an information
+        about <code>socket.directSslBuffer</code>. (violetagg)
+      </fix>
+      <fix>
+        <bug>60034</bug>: Correct a typo in the Manager How-To page of the
+        documentation web application. (markt)
+      </fix>
+      <fix>
+        Correct the name of the CRL location configuration attributes in the
+        documentation web application. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="jdbc-pool">
+    <changelog>
+      <fix>
+        In order to avoid the unintended skip of <code>PoolCleaner</code>,
+        remove the check code of the execution interval in the task that has
+        been scheduled. (kfujino)
+      </fix>
+      <fix>
+        <bug>59850</bug>: Ensure that the <code>ResultSet</code> is closed when
+        enabling the <code>StatementCache</code> interceptor. (kfujino)
+      </fix>
+      <fix>
+        <bug>59923</bug>: Reduce the default value of
+        <code>validationInterval</code> in order to avoid the potential issue
+        that continues to return an invalid connection after database restart.
+        (kfujino)
+      </fix>
+      <fix>
+        Ensure that the <code>ResultSet</code> is returned as Proxy object when
+        enabling the <code>StatementDecoratorInterceptor</code>. (kfujino)
+      </fix>
+      <fix>
+        <bug>60043</bug>: Ensure that the <code>suspectTimeout</code> works
+        without removing connection when the <code>removeAbandoned</code> is
+        disabled. (kfujino)
+      </fix>
+      <fix>
+        Add log message of when returning the connection that has been marked
+        suspect. (kfujino)
+      </fix>
+      <fix>
+        Correct Javadoc for <code>ConnectionPool.suspect()</code>. Based on a
+        patch by Yahya Cahyadi. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Other">
+    <changelog>
+      <add>
+        <bug>59871</bug>: Add a property (<code>timeFormat</code>) to
+        JULI&apos;s <code>OneLineFormatter</code> to enable the format of the
+        time stamp used in log messages to be configured. (markt)
+      </add>
+      <fix>
+        <bug>59899</bug>: Update Tomcat&apos;s copy of the Java Persistence
+        annotations to include the changes made in 2.1 / JavaEE 7. (markt)
+      </fix>
+      <fix>
+        Fixed typos in mbeans-descriptors.xml files. (violetagg)
+      </fix>
+      <update>
+        Update the internal fork of Commons BCEL to r1757132 to align with the
+        BCEL 6 release. (markt)
+      </update>
+      <update>
+        Update the internal fork of Commons DBCP2 to r1757164 to pick up a
+        couple of bug fixes. (markt)
+      </update>
+      <update>
+        Update the internal fork of Commons Codec to r1757174. Code formatting
+        changes only. (markt)
+      </update>
+      <update>
+        Update the internal fork of Commons FileUpload to afdedc9. This pulls in
+        a fix to improve the performance with large multipart boundaries.
+        (markt)
+      </update>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.0.M9 (markt)" rtext="2016-07-12">
+  <subsection name="Catalina">
+    <changelog>
+      <fix>
+        <bug>18500</bug>: Add limited support for wildcard host names and host
+        aliases. Names of the form <code>*.domainname</code> are now permitted.
+        Note that an exact host name match takes precedence over a wild card
+        host name match. (markt)
+      </fix>
+      <fix>
+        <bug>57705</bug>: Add debug logging for requests denied by the remote
+        host and remote address valves and filters. Based on a patch by Graham
+        Leggett. (markt)
+      </fix>
+      <fix>
+        Correct a regression in the fix for <bug>58588</bug> that removed the
+        entire <code>org.apache.juli</code> package from the embedded JARs
+        rendering them unusable. (markt)
+      </fix>
+      <add>
+        <bug>59399</bug>: Add a new option to the Realm implementations that
+        ship with Tomcat that allows the HTTP status code used for HTTP -> HTTPS
+        redirects to be controlled per Realm. (markt)
+      </add>
+      <fix>
+        <bug>59708</bug>: Modify the LockOutRealm logic. Valid authentication
+        attempts during the lock out period will no longer reset the lock out
+        timer to zero. (markt)
+      </fix>
+      <update>
+        Change the default of the
+        <code>sessionCookiePathUsesTrailingSlash</code> attribute of the
+        <code>Context</code> element to <code>false</code> since the problems
+        caused when a Servlet is mapped to <code>/*</code> are more significant
+        than the security risk of not enabling this option by default. (markt)
+      </update>
+      <fix>
+        Follow-up to <bug>59655</bug>. Improve the documentation for configuring
+        permitted cookie names. Patch provided by Kyohei Nakamura. (markt)
+      </fix>
+      <fix>
+        Do not attempt to start web resources during a web application's
+        initialisation phase since the web application is not fully configured
+        at that point and the web resources may not be correctly configured.
+        (markt)
+      </fix>
+      <fix>
+        Improve error handling around user code prior to calling
+        <code>InstanceManager.destroy()</code> to ensure that the method is
+        executed. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Coyote">
+    <changelog>
+      <fix>
+        Fix a cause of multiple attempts to close the same socket. (markt)
+      </fix>
+      <scode>
+        Refactor the certificate keystore and trust store generation to make it
+        easier for embedded users to inject their own key stores. (markt)
+      </scode>
+      <update>
+        Add a <code>maxConcurrentStreamExecution</code> on the HTTP/2
+        protocol handler to allow restricting the amount of concurrent stream
+        that are being executed in a single connection. The default is to
+        not limit it. (remm)
+      </update>
+      <add>
+        <bug>59233</bug>: Add the ability to add TLS virtual hosts dynamically.
+        (markt)
+      </add>
+      <fix>
+        Correct a problem with <code>ServletRequest.getServerPort()</code> for
+        secure HTTP/2 connections that meant an incorrect value was returned when
+        using the default port. (markt)
+      </fix>
+      <fix>
+        Improve error handling around user code prior to calling
+        <code>InstanceManager.destroy()</code> to ensure that the method is
+        executed. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Jasper">
+    <changelog>
+      <fix>
+        Improve error handling around user code prior to calling
+        <code>InstanceManager.destroy()</code> to ensure that the method is
+        executed. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="WebSocket">
+    <changelog>
+      <scode>
+        Now the WebSocket implementation is not built directly on top of the
+        Servlet API and can use Tomcat internals, there is no need for the
+        dedicated WebSocket Executor. It has been replaced by the use of the
+        Connector/Endpoint provided Executor. (markt)
+      </scode>
+      <fix>
+        Improve error handling around user code prior to calling
+        <code>InstanceManager.destroy()</code> to ensure that the method is
+        executed. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Web Applications">
+    <changelog>
+      <fix>
+        Do not log an additional case of <code>IOException</code>s in the
+        error handler for the Drawboard WebSocket example when the root cause is
+        the client disconnecting since the logs add no value. (markt)
+      </fix>
+      <fix>
+        <bug>59642</bug>: Mention the <code>localDataSource</code> in the
+        <code>DataSourceRealm</code> section of the Realm How-To. (markt)
+      </fix>
+      <fix>
+        <bug>59672</bug>: Update the security considerations page of the
+        documentation web application to take account of the fact that the
+        Manager and HostManager applications now have a
+        <code>RemoteAddrValve</code> configured by default. (markt)
+      </fix>
+      <fix>
+        Follow-up to the fix for <bug>59399</bug>. Ensure that the new attribute
+        <code>transportGuaranteeRedirectStatus</code> is documented for all
+        <strong>Realm</strong>s. Also document the <code>NullRealm</code> and
+        when it is automatically created for an <strong>Engine</strong>. (markt)
+      </fix>
+      <fix>
+        Fix the description of <code>maxAge</code> attribute in jdbc-pool doc.
+        This attribute works both when a connection is returned and when a
+        connection is borrowed. (kfujino)
+      </fix>
+      <fix>
+        <bug>59774</bug>: Correct the <code>prefix</code> values in the
+        documented examples for configuring the <code>AccessLogValve</code>.
+        Patch provided by Mike Noordermeer. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Tribes">
+    <changelog>
+      <add>
+        Add log message when the ping has timed-out. (kfujino)
+      </add>
+      <fix>
+        If the ping message has been received at the
+        <code>AbstractReplicatedMap#leftOver</code> method, ensure that notify
+        the member is alive than ignore it. (kfujino)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="jdbc-pool">
+    <changelog>
+      <fix>
+        Fix the duplicated connection release when connection verification
+        failed. (kfujino)
+      </fix>
+      <fix>
+        Ensure that do not remove the abandoned connection that has been already
+        released. (kfujino)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Other">
+    <changelog>
+      <fix>
+        Remove JULI plus log4j extras and embedded artifacts from Maven release
+        script. (markt)
+      </fix>
+      <add>
+        Use the mirror network rather than the ASF master site to download the
+        current ASF dependencies. (markt)
+      </add>
+      <update>
+        Update the packaged version of the Tomcat Native Library to 1.2.8 to
+        pick up the latest fixes and make 1.2.8 the minimum recommended version.
+        (markt)
+      </update>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.0.M8 (markt)" rtext="2016-06-13">
+  <subsection name="Coyote">
+    <changelog>
+      <fix>
+        Remove accidentally committed debug code. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.0.M7 (markt)" rtext="not released">
+  <subsection name="Catalina">
+    <changelog>
+      <fix>
+        RMI Target related memory leaks are avoidable which makes them an
+        application bug that needs to be fixed rather than a JRE bug to work
+        around. Therefore, start logging RMI Target related memory leaks on web
+        application stop. Add an option that controls if the check for these
+        leaks is made. Log a warning if running on Java 9 with this check
+        enabled but without the command line option it requires. (markt)
+      </fix>
+      <fix>
+        Ensure NPE will not be thrown during deployment when scanning jar files
+        without MANIFEST.MF file. (violetagg)
+      </fix>
+      <scode>
+        Remove the <code>clearReferencesStatic</code> option from
+        <code>StandardContext</code>. It was known to cause problems with some
+        libraries (such as log4j) and was only linked to suspected memory leaks
+        rather than known memory leaks. It had been disabled by default with no
+        increase in the reports of memory leaks for some time. (markt)
+      </scode>
+      <fix>
+        <bug>59604</bug>: Correct the assumption made in the URL decoding that
+        the default platform encoding is always compatible with ISO-8859-1. This
+        assumption is not always valid, e.g. on z/OS. (markt)
+      </fix>
+      <fix>
+        <bug>59608</bug>: Skip over any invalid <code>Class-Path</code> attribute
+        from JAR manifests. Log errors at debug level due to many bad libraries.
+        (remm)
+      </fix>
+      <fix>
+        Fix error message when failed to register MBean. (kfujino)
+      </fix>
+      <fix>
+        <bug>59655</bug>: Configure the cookie name validation to use RFC6265
+        rules by default to align it with the default cookie parser. Document
+        the impact system properties have on cookie name validation. (mark)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Coyote">
+    <changelog>
+      <fix>
+        Ensure that requests with HTTP method names that are not tokens (as
+        required by RFC 7231) are rejected with a 400 response. (markt)
+      </fix>
+      <fix>
+        When an asynchronous request is processed by the AJP connector, ensure
+        that request processing has fully completed before starting the next
+        request. (markt)
+      </fix>
+      <fix>
+        Improve handling of HTTP/2 stream resets. (markt)
+      </fix>
+      <add>
+        <bug>58750</bug>: The HTTP Server header is no longer set by default. A
+        Server header may be configured by setting the <code>server</code>
+        attribute on the <code>Connector</code>. A new <code>Connector</code>
+        attribute, <code>serverRemoveAppProvidedValues</code> may be used to
+        remove any Server header set by a web application. (markt)
+      </add>
+      <fix>
+        <bug>59564</bug>: Correct offset when reading into HTTP/2 input buffer
+        that could cause problems reading request bodies. (violetagg/markt)
+      </fix>
+      <fix>
+        Modify the handling of read/write timeouts so that the appropriate error
+        handling (<code>ReadListener.onError()</code>,
+        <code>WriteListener.onError()</code> or
+        <code>AsyncListener.onError()</code>) is called. (markt)
+      </fix>
+      <fix>
+       If an async dispatch results in the completion of request processing,
+       ensure that any remaining request body is swallowed before starting the
+       processing of the next request else the remaining body may be read as the
+       start of the next request leading to a 400 response. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Jasper">
+    <changelog>
+      <fix>
+        <bug>59567</bug>: Fix NPE scanning webapps for TLDs when an exploded
+        JAR has an empty WEB-INF/classes/META-INF folder. (remm)
+      </fix>
+      <fix>
+        Fix a memory leak in the expression language implementation that caused
+        the class loader of the first web application to use expressions to be
+        pinned in memory. (markt)
+      </fix>
+      <fix>
+        <bug>59654</bug>: Improve error message when attempting to use a TLD
+        file from an invalid location. Patch provided by Huxing Zhang. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="WebSocket">
+    <changelog>
+      <fix>
+        <bug>59659</bug>: Fix possible memory leak in WebSocket handling of
+        unexpected client disconnects. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Web applications">
+    <changelog>
+      <fix>
+        <bug>58891</bug>: Update the SSL how-to. Based on a suggestion by
+        Alexander Kjäll. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Extras">
+    <changelog>
+      <scode>
+        <bug>58588</bug>: Remove the JULI extras package from the distribution.
+        It was only useful for switching Tomcat's internal logging to log4j
+        1.2.x and that version of log4j is no longer supported. No additional
+        Tomcat code is required if switching Tomcat's internal logging to log
+        via log4j 2.x. (markt)
+      </scode>
+    </changelog>
+  </subsection>
+  <subsection name="jdbc-pool">
+    <changelog>
+      <fix>
+        Fix a memory leak with the pool cleaner thread that retained a reference
+        to the web application class loader for the first web application to use
+        a connection pool. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Other">
+    <changelog>
+      <update>
+        Update the internal fork of Commons DBCP 2 to r1743696 (2.1.1 plus
+        additional fixes). (markt)
+      </update>
+      <update>
+        Update the internal fork of Commons Pool 2 to r1743697 (2.4.2 plus
+        additional fixes). (markt)
+      </update>
+      <update>
+        Update the internal fork of Commons File Upload to r1743698 (1.3.1 plus
+        additional fixes). (markt)
+      </update>
+      <scode>
+        Use UTF-8 with a standard prolog for all XML files. (markt)
+      </scode>
+      <fix>
+        <bug>58626</bug>: Add support for a new environment variable
+        (<code>USE_NOHUP</code>) that causes <code>nohup</code> to be used when
+        starting Tomcat. It is disabled by default except on HP-UX where it is
+        enabled by default since it is required when starting Tomcat at boot on
+        HP-UX. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.0.M6 (markt)" rtext="2016-05-16">
+  <subsection name="Catalina">
+    <changelog>
+      <fix>
+        Ensure that annotated web components packed in web fragments will be
+        processed when <code>unpackWARs</code> is enabled. (violetagg)
+      </fix>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.0.M5 (markt)" rtext="not released">
+  <subsection name="Catalina">
+    <changelog>
+      <fix>
+        <bug>48922</bug>: Apply a very small performance improvement to the
+        date formatting in Tomcat's internal request object. Based on a patch
+        provided by Ondrej Medek. (markt)
+      </fix>
+      <fix>
+        <bug>59206</bug>: Ensure NPE will not be thrown by
+        <code>o.a.tomcat.util.file.ConfigFileLoader</code> when
+        <code>catalina.base</code> is not specified. (violetagg)
+      </fix>
+      <fix>
+        <bug>59217</bug>: Remove duplication in the recycling of the path in
+        <code>o.a.tomcat.util.http.ServerCookie</code>. Patch is provided by
+        Kyohei Nakamura. (violetagg)
+      </fix>
+      <fix>
+        Fixed possible NPE in
+        <code>o.a.catalina.loader.WebappClassLoaderBase.getResourceAsStream</code>
+        (violetagg)
+      </fix>
+      <fix>
+        <bug>59213</bug>: Async dispatches should be based off a wrapped
+        request. (remm)
+      </fix>
+      <fix>
+        Ensure that <code>javax.servlet.ServletRequest</code> and
+        <code>javax.servlet.ServletResponse</code> provided during
+        <code>javax.servlet.AsyncListener</code> registration are made
+        available via <code>javax.servlet.AsyncEvent.getSuppliedRequest</code>
+        and <code>javax.servlet.AsyncEvent.getSuppliedResponse</code>
+        (violetagg)
+      </fix>
+      <fix>
+        <bug>59219</bug>: Ensure <code>AsyncListener.onError()</code> is called
+        if an <code>Exception</code> is thrown during async processing. (markt)
+      </fix>
+      <fix>
+        <bug>59220</bug>: Ensure that <code>AsyncListener.onComplete()</code> is
+        called if the async request times out and the response is already
+        committed. (markt)
+      </fix>
+      <fix>
+        <bug>59226</bug>: Process the <code>Class-Path</code> attribute from
+        JAR manifests for JARs on the class path excluding JARs packaged in
+        <code>WEB-INF/lib</code>. (markt)
+      </fix>
+      <fix>
+        <bug>59255</bug>: Fix possible NPE in mapper. (kkolinko/remm)
+      </fix>
+      <fix>
+        <bug>59256</bug>: <code>slf4j-taglib*.jar</code> should not be excluded
+        from the standard JAR scanning by default. (violetagg)
+      </fix>
+      <fix>
+        Clarify the log message that specifying both urlPatterns and value
+        attributes in @WebServlet and @WebFilter annotations is not allowed.
+        (violetagg)
+      </fix>
+      <fix>
+        Ensure the exceptions caused by Valves will be available in the log
+        files so that they can be evaluated when
+        <code>o.a.catalina.valves.ErrorReportValve.showReport</code> is
+        disabled. Patch is provided by Svetlin Zarev. (violetagg)
+      </fix>
+      <fix>
+        Remove unused <code>distributable</code> attribute that is defined as
+        <code>TransientAttribute</code> of <code>Manager</code> in StoreConfig.
+        (kfujino)
+      </fix>
+      <fix>
+        Fix handling of Cluster Receiver in StoreConfig. The <code>bind</code>
+        and <code>host</code> attributes define as
+        <code>TransientAttribute</code>. (kfujino)
+      </fix>
+      <fix>
+        <bug>59261</bug>: <code>ServletRequest.getAsyncContext()</code> now
+        throws an <code>IllegalStateException</code> as required by the Servlet
+        specification if the request is not in asynchronous mode when called.
+        (markt)
+      </fix>
+      <fix>
+        <bug>59269</bug>: Correct the implementation of
+        <code>PersistentManagerBase</code> so that <code>minIdleSwap</code>
+        functions as designed and sessions are swapped out to keep the active
+        session count below <code>maxActiveSessions</code>. (markt)
+      </fix>
+      <update>
+        Update the implementation of the proposed Servlet 4.0 API to provide
+        mapping type information for the current request to reflect discussions
+        within the EG. (markt)
+      </update>
+      <fix>
+        Correctly configure the base path for a resources directory provided by
+        an expanded JAR file. Patch provided by hengyunabc. (markt)
+      </fix>
+      <add>
+        When multiple compressed formats are available and the client does not
+        express a preference, use the server order to determine the preferred
+        format. Based on a patch by gmokki. (markt)
+      </add>
+      <fix>
+        <bug>59284</bug>: Allow the Tomcat provided JASPIC
+        <code>SimpleServerAuthConfig</code> to pick up module configuration
+        properties from either the property set passed to its constructor or
+        from the properties passed in the call to <code>getAuthContext</code>.
+        Based on a patch by Thomas Maslen. (markt)
+      </fix>
+      <fix>
+        <bug>59310</bug>: Do not add a <code>Content-Length: 0</code> header for
+        custom responses to <code>HEAD</code> requests that do not set a
+        <code>Content-Length</code> value. (markt)
+      </fix>
+      <fix>
+        When normalizing paths, improve the handling when paths end with
+        <code>/.</code> or <code>/..</code> and ensure that input and output are
+        consistent with respect to whether or not they end with <code>/</code>.
+        (markt)
+      </fix>
+      <fix>
+        <bug>59317</bug>: Ensure that
+        <code>HttpServletRequest.getRequestURI()</code> returns an encoded URI
+        rather than a decoded URI after a dispatch. (markt)
+      </fix>
+      <fix>
+        Use the correct URL for the fragment when reporting errors processing
+        a <code>web-fragment.xml</code> file from a JAR located in an unpacked
+        WAR. (markt)
+      </fix>
+      <fix>
+        Ensure that <code>JarScanner</code> only uses the explicit call-back to
+        process <code>WEB-INF/classes</code> and only when configured to treat
+        the contents of <code>WEB-INF/classes</code> as a possible exploded JAR.
+        (markt)
+      </fix>
+      <scode>
+        Remove the <code>java2DDisposerProtection</code> option from the
+        <code>JreMemoryLeakPreventionListener</code>. The leak is fixed in Java
+        7 onwards and Tomcat 9 requires Java 8 so the option is unnecessary.
+        (markt)
+      </scode>
+      <scode>
+        Remove the <code>securityPolicyProtection</code> option from the
+        <code>JreMemoryLeakPreventionListener</code>. The leak is fixed in Java
+        8 onwards and Tomcat 9 requires Java 8 so the option is unnecessary.
+        (markt)
+      </scode>
+      <scode>
+        Remove the <code>securityLoginConfigurationProtection</code> option from
+        the <code>JreMemoryLeakPreventionListener</code>. The leak is fixed in
+        Java 8 onwards and Tomcat 9 requires Java 8 so the option is
+        unnecessary. (markt)
+      </scode>
+      <fix>
+        Ensure that the value for the header <code>X-Frame-Options</code> is
+        constructed correctly according to the specification when
+        <code>ALLOW-FROM</code> option is used. (violetagg)
+      </fix>
+      <fix>
+        Fix an <code>IllegalArgumentException</code> if the first use of an
+        internal <code>Response</code> object requires JASPIC authentication.
+        (markt)
+      </fix>
+      <fix>
+        Do not trigger unnecessary session ID changes when using JASPIC and the
+        user is authenticated using cached credentials. (markt)
+      </fix>
+      <fix>
+        <bug>59437</bug>: Ensure that the JASPIC <code>CallbackHandler</code> is
+        thread-safe. (markt)
+      </fix>
+      <fix>
+        <bug>59449</bug>: In <code>ContainerBase</code>, ensure that the process
+        to remove a child container is the reverse of the process to add one.
+        Patch provided by Huxing Zhang. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Coyote">
+    <changelog>
+      <fix>
+        Improves OpenSSL engine robustness when SSL allocation fails for
+        some reason. (remm)
+      </fix>
+      <fix>
+        OpenSSL engine code cleanups. (remm)
+      </fix>
+      <fix>
+        Align cipher configuration parsing with current OpenSSL master. (markt)
+      </fix>
+      <update>
+        Change the default for <code>honorCipherOrder</code> to
+        <code>false</code>. With the current default TLS configuration, it is no
+        longer necessary for this to be <code>true</code> for a reasonably
+        secure configuration. (markt)
+      </update>
+      <add>
+        Add a new environment variable <code>JSSE_OPTS</code> that is intended
+        to be used to pass JVM wide configuration to the JSSE implementation.
+        The default value is <code>-Djdk.tls.ephemeralDHKeySize=2048</code>
+        which protects against weak Diffie-Hellman keys. (markt)
+      </add>
+      <fix>
+        <bug>58970</bug>: Fix a connection counting bug in the NIO connector
+        that meant some dropped connections were not removed from the current
+        connection count. (markt)
+      </fix>
+      <fix>
+        <bug>59289</bug>: Do not recycle upgrade processors in unexpected close
+        situations. (remm)
+      </fix>
+      <fix>
+        <bug>59295</bug>: Use <code>Locale.toLanguageTag()</code> to construct
+        the <code>Content-Language</code> HTTP header to ensure the locale is
+        correctly represented. Patch provided by zikfat. (markt)
+      </fix>
+      <update>
+        <bug>59295</bug>: Add support for using pem encoded certificates with
+        JSSE SSL. Submitted by Emmanuel Bourg with additional tweaks. (remm)
+      </update>
+      <fix>
+        Make the TLS certificate chain available to clients when using
+        JSSE+OpenSSL with the certificate chain stored in a Java KeyStore.
+        (markt)
+      </fix>
+      <fix>
+        Work around <a href="https://github.com/openssl/openssl/issues/188">a
+        known issue in OpenSSL</a> that does not permit the TLS handshake to be
+        failed if the ALPN negotiation fails. (markt)
+      </fix>
+      <update>
+        <bug>59421</bug>: Add direct HTTP/2 connection support. (remm)
+      </update>
+      <fix>
+        Correctly handle a call to <code>AsyncContext.complete()</code> from a
+        non-container thread when non-blocking I/O is being used. (markt)
+      </fix>
+      <fix>
+        <bug>59451</bug>: Correct Javadoc for <code>MessageBytes</code>. Patch
+        provided by Kyohei Nakamura. (markt)
+      </fix>
+      <fix>
+        <bug>59450</bug>: Correctly handle the case where the
+        <code>LegacyCookieProcessor</code> is configured with
+        <code>allowHttpSepsInV0</code> set to <code>false</code> and
+        <code>forwardSlashIsSeparator</code> set to <code>true</code>. Patch
+        provided by Kyohei Nakamura. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Jasper">
+    <changelog>
+      <fix>
+        When scanning JARs for TLDs, correctly handle the (rare) case where a
+        JAR has been exploded into <code>WEB-INF/classes</code> and the web
+        application is deployed as a packed WAR. (markt)
+      </fix>
+      <fix>
+        <bug>59640</bug>: NPEs with not found TLDs. (remm)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="WebSocket">
+    <changelog>
+      <fix>
+        <bug>59189</bug>: Explicitly release the native memory held by the
+        <code>Inflater</code> and <code>Deflater</code> when using
+        PerMessageDeflate and the WebSocket session ends. Based on a patch by
+        Henrik Olsson. (markt)
+      </fix>
+      <fix>
+        Restore the <code>WsServerContainer.doUpgrade()</code> method which was
+        accidentally removed since it is not used by Tomcat. (markt)
+      </fix>
+      <fix>
+        Fix a regression caused by the connector refactoring and ensure that the
+        thread context class loader is set to the web application
+        classloader when processing WebSocket messages on the server. (markt)
+      </fix>
+      <fix>
+        Ensure that a client disconnection triggers the error handling for the
+        associated WebSocket end point. (markt)
+      </fix>
+      <add>
+        Make WebSocket client more robust when handling errors during the close
+        of a WebSocket session. (markt)
+      </add>
+    </changelog>
+  </subsection>
+  <subsection name="Web applications">
+    <changelog>
+      <fix>
+        <bug>59218</bug>: Correct the path to <code>jaspic-providers.xml</code>
+        in Jaspic How-To. Patch is provided by Tatsuya Bessho. (violetagg)
+      </fix>
+      <fix>
+        Remove button that has accidentally been added to the host manager.
+        Submitted by Coty Sutherland. (remm)
+      </fix>
+      <fix>
+        Update in the documentation the link to the maven repository where
+        Tomcat snapshot artifacts are deployed. (markt/violetagg)
+      </fix>
+      <fix>
+        Clarify in the documentation that calls to
+        <code>ServletContext.log(String, Throwable)</code> or
+        <code>GenericServlet.log(String, Throwable)</code> are logged at the
+        SEVERE level. (violetagg)
+      </fix>
+      <fix>
+        Correct a typo in SSL/TLS Configuration How-To.
+        Issue reported via comments.apache.org. (violetagg)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Tribes">
+    <changelog>
+      <fix>
+        Avoid NPE when a proxy node failed to retrieve a backup entry. (kfujino)
+      </fix>
+      <add>
+        Add the flag indicating that member is a localMember. (kfujino)
+      </add>
+      <fix>
+        Fix potential NPE that depends on the setting order of attributes of
+        static member when using the static cluster. (kfujino)
+      </fix>
+      <add>
+        Add get/set method for the channel that is related to
+        <code>ChannelInterceptor</code>. (kfujino)
+      </add>
+      <fix>
+        As with the multicast cluster environment, in the static cluster
+        environment, the local member inherits properties from the cluster
+        receiver. (kfujino)
+      </fix>
+      <add>
+        Add get/set method for the channel that is related to each Channel
+        services. (kfujino)
+      </add>
+      <add>
+        Add name to channel in order to identify channels. In tomcat cluster
+        environment, it is set the cluster name + "-Channel" as default value.
+        (kfujino)
+      </add>
+      <add>
+        Add the channel name to the thread which is invoked by channel services
+        in order to identify the associated channel. (kfujino)
+      </add>
+      <fix>
+        Ensure that clear the channel instance from channel services when
+        stopping channel. (kfujino)
+      </fix>
+      <add>
+        Implement map state in the replication map. (kfujino)
+      </add>
+      <fix>
+        Ensure that the ping is not executed during the start/stop of the
+        replication map. (kfujino)
+      </fix>
+      <fix>
+        In ping processing in the replication map, send not the
+        <code>INIT</code> message but the newly introduced <code>PING</code>
+        message. (kfujino)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Other">
+    <changelog>
+      <fix>
+        <bug>59211</bug>: Add hamcrest to Eclipse classpath. Patch is provided
+        by Huxing Zhang. (violetagg)
+      </fix>
+      <update>
+        <bug>59276</bug>: Update optional Checkstyle library to 6.17.
+        (kkolinko)
+      </update>
+      <update>
+        <bug>59280</bug>: Update the NSIS Installer used to build the
+        Windows Installers to version 2.51. (kkolinko)
+      </update>
+      <update>
+        Update the packaged version of the Tomcat Native Library to 1.2.7 to
+        pick up the Windows binaries that are based on OpenSSL 1.0.2h and APR
+        1.5.2. (markt)
+      </update>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.0.M4 (markt)" rtext="2016-03-16">
+  <subsection name="Catalina">
+    <changelog>
+      <fix>
+        Ensure that <code>/WEB-INF/classes</code> is never processed as a web
+        fragment. (markt)
+      </fix>
+      <update>
+        Switch default connector when native is installed. Unless configured
+        otherwise, the NIO endpoint will be used by default. If SSL is
+        configured, OpenSSL will be used rather than JSSE. (remm)
+      </update>
+      <fix>
+        Correct a regression in the fix for <bug>58867</bug>. When configuring a
+        Context to use an external directory for the <code>docBase</code>, and
+        that directory happens to be located along side the original WAR, use
+        the directory as the <code>docBase</code> rather than expanding the
+        WAR into the <code>appBase</code> and using the newly created expanded
+        directory as the <code>docBase</code>. (markt)
+      </fix>
+      <add>
+        <bug>58351</bug>: Make the server build date and server version number
+        accessible via JMX. Patch provided by  Huxing Zhang. (markt)
+      </add>
+      <add>
+        <bug>58988</bug>: Special characters in the substitutions for the
+        RewriteValve can now be quoted with a backslash. (fschumacher)
+      </add>
+      <fix>
+        <bug>58999</bug>: Fix class and resource name filtering in
+        WebappClassLoader. It throws a StringIndexOutOfBoundsException if the
+        name is exactly "org" or "javax". (rjung)
+      </fix>
+      <add>
+        Add JASPIC (JSR-196) support. (markt)
+      </add>
+      <add>
+        Make checking for var and map replacement in RewriteValve a bit stricter
+        and correct detection of colon in var replacement. (fschumacher)
+      </add>
+      <fix>
+        Refactor the web application class loader to reduce the impact of JAR
+        scanning on the memory footprint of the web application. (markt)
+      </fix>
+      <fix>
+        Fix some resource leaks in the error handling for accessing files from
+        JARs and WARs. (markt)
+      </fix>
+      <fix>
+        Refactor the JAR and JAR-in-WAR resource handling to reduce the memory
+        footprint of the web application. (markt)
+      </fix>
+      <fix>
+        Refactor the web.xml parsing so a new parser is created every time the
+        web application starts rather than creating and caching the parser when
+        the Context is created. This enables the parser to take account of
+        modified Context configuration parameters and reduces (slightly) the
+        memory footprint of a running Tomcat instance. (markt)
+      </fix>
+      <update>
+        Switch the web application class loader to the
+        <code>ParallelWebappClassLoader</code> by default. (markt)
+      </update>
+      <fix>
+        <bug>57809</bug>: Remove the custom context attribute that held the
+        effective web.xml. Components needing access to configuration
+        information may access it via the Servlet API. (markt)
+      </fix>
+      <fix>
+        Refactor JAR scanning to reduce memory footprint. (markt)
+      </fix>
+      <fix>
+        <bug>59001</bug>: Correctly handle the case when Tomcat is installed on
+        a path where one of the segments ends in an exclamation mark. (markt)
+      </fix>
+      <fix>
+        Expand the fix for <bug>59001</bug> to cover the special sequences used
+        in Tomcat&apos;s custom jar:war: URLs. (markt)
+      </fix>
+      <fix>
+        <bug>59043</bug>: Avoid warning while expiring sessions associated with
+        a single sign on if <code>HttpServletRequest.logout()</code> is used.
+        (markt)
+      </fix>
+      <fix>
+        <bug>59054</bug>: Ensure that using the
+        <code>CrawlerSessionManagerValve</code> in a distributed environment
+        does not trigger an error when the Valve registers itself in the
+        session. (markt)
+      </fix>
+      <fix>
+        Add socket properties support to storeconfig. (remm)
+      </fix>
+      <fix>
+        Fix incorrect parsing of the NE and NC flags in rewrite rules. (remm)
+      </fix>
+      <fix>
+        <bug>59065</bug>: Correct the timing of the check for colons in paths
+        on non-Windows systems implemented in <code>catalina.sh</code> so it
+        works correctly with Cygwin. Patch provided by Ed Randall. (markt)
+      </fix>
+      <fix>
+        When a Host is configured with an appBase that does not exist, create
+        the appBase before trying to expand an external WAR file into it.
+        (markt)
+      </fix>
+      <fix>
+       <bug>59115</bug>: When using the Servlet 3.0 file upload, the submitted
+       file name may be provided as a token or a quoted-string. If a
+       quoted-string, unquote the string before returning it to the user.
+       (markt)
+      </fix>
+      <fix>
+        <bug>59123</bug>: Close <code>NamingEnumeration</code> objects used by
+        the <code>JNDIRealm</code> once they are no longer required.
+        (fschumacher/markt)
+      </fix>
+      <add>
+        Implement the proposed Servlet 4.0 API to provide mapping type
+        information for the current request. (markt)
+      </add>
+      <fix>
+        <bug>59138</bug>: Correct a false positive warning for ThreadLocal
+        related memory leaks when the key class but not the value class has been
+        loaded by the web application class loader. (markt)
+      </fix>
+      <add>
+        <bug>59017</bug>: Make the pre-compressed file support in the Default
+        Servlet generic so any compression may be used rather than just gzip.
+        Patch provided by Mikko Tiihonen. (markt)
+      </add>
+      <fix>
+        <bug>59145</bug>: Don't log an invalid warning when a user logs out of
+        a session associated with SSO. (markt)
+      </fix>
+      <fix>
+        <bug>59150</bug>: Add an additional flag on APR listener to allow
+        disabling automatic use of OpenSSL. (remm)
+      </fix>
+      <fix>
+        <bug>59151</bug>: Fix a regression in the fix for <bug>56917</bug> that
+        added additional (and arguably unnecessary) validation to the provided
+        redirect location. (markt)
+      </fix>
+      <fix>
+        <bug>59154</bug>: Fix a <code>NullPointerException</code> in the
+        <code>JAASMemoryLoginModule</code> resulting from the introduction of
+        the <code>CredentialHandler</code> to <code>Realm</code>s.
+        (schultz/markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Coyote">
+    <changelog>
+      <fix>
+        Handle the case in the NIO2 connector where the required TLS buffer
+        sizes increase after the connection has been initiated. (markt/remm)
+      </fix>
+      <fix>
+        Bad processing of handshake errors in NIO2. (remm)
+      </fix>
+      <fix>
+        Use JSSE session configuration options with OpenSSL. (remm)
+      </fix>
+      <fix>
+        <bug>59015</bug>: Fix potential cause of endless APR Poller loop during
+        shutdown if the Poller experiences an error during the shutdown process.
+        (markt)
+      </fix>
+      <fix>
+        Align cipher aliases for <code>kECDHE</code> and <code>ECDHE</code> with
+        the current OpenSSL implementation. (markt)
+      </fix>
+      <fix>
+        <bug>59081</bug>: Retain the user defined cipher order when defining
+        ciphers. (markt)
+      </fix>
+      <fix>
+        <bug>59089</bug>: Correctly ignore HTTP headers that include non-token
+        characters in the header name. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Jasper">
+    <changelog>
+      <update>
+        Update to the Eclipse JDT Compiler 4.5.1. (markt)
+      </update>
+      <fix>
+        <bug>57583</bug>: Improve the performance of
+        <code>javax.servlet.jsp.el.ScopedAttributeELResolver</code> when
+        resolving attributes that do not exist. This improvement only works when
+        Jasper is used with Tomcat's EL implementation. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="WebSocket">
+    <changelog>
+      <fix>
+        Fix a timing issue on session close that could result in an exception
+        being thrown for an incomplete message even through the message was
+        completed. (markt)
+      </fix>
+      <fix>
+        Correctly handle compression of partial messages when the final message
+        fragment has a zero length payload. (markt)
+      </fix>
+      <fix>
+        <bug>59119</bug>: Correct read logic for WebSocket client when using
+        secure connections. (markt)
+      </fix>
+      <fix>
+        <bug>59134</bug>: Correct client connect logic for secure connections
+        made through a proxy. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Web applications">
+    <changelog>
+      <fix>
+        Correct an error in the documentation of the expected behaviour for
+        automatic deployment. If a WAR is updated and an expanded directory is
+        present, the directory will always be deleted and recreated by expanding
+        the WAR if <code>unpackWARs</code> is <code>true</code>. (markt)
+      </fix>
+      <fix>
+        <bug>48674</bug>: Implement an option within the Host Manager web
+        application to persist the current configuration. Based on a patch by
+        Coty Sutherland. (markt)
+      </fix>
+      <fix>
+        <bug>58935</bug>: Remove incorrect references in the documentation to
+        using <code>jar:file:</code> URLs with the Manager application. (markt)
+      </fix>
+      <fix>
+        Correct the description of the
+        <code>ServletRequest.getServerPort()</code> in Proxy How-To.
+        Issue reported via comments.apache.org. (violetagg)
+      </fix>
+      <add>
+        The Manager and Host Manager applications are now only accessible via
+        <code>localhost</code> by default. (markt)
+      </add>
+    </changelog>
+  </subsection>
+  <subsection name="Tribes">
+    <changelog>
+      <fix>
+        If promoting a proxy node to a primary node when getting a session,
+        notify the change of the new primary node to the original backup node.
+        (kfujino)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Other">
+    <changelog>
+      <fix>
+        <bug>58283</bug>: Change the default download location for libraries
+        during the build process from <code>/usr/share/java</code> to
+        <code>${user.home}/temp</code>. Patch provided by Ahmed Hosni. (markt)
+      </fix>
+      <fix>
+        <bug>59031</bug>: When using the Windows uninstaller, do not remove the
+        contents of any directories that have been symlinked into the Tomcat
+        directory structure. (markt)
+      </fix>
+      <update>
+        Update the packaged version of the Tomcat Native Library to 1.2.5 to
+        pick up the Windows binaries that are based on OpenSSL 1.0.2g and APR
+        1.5.1. (markt)
+      </update>
+      <update>
+        Modify the default <code>tomcat-users.xml</code> file to make it harder
+        for users to configure the entries intended for use with the examples
+        web application for the Manager application. (markt)
+      </update>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.0.M3 (markt)" rtext="2016-02-05">
+  <subsection name="General">
+    <changelog>
+      <add>
+        Allow to configure multiple JUnit test class patterns with the build
+        property <code>test.name</code> and document the property in
+        BUILDING.txt. (rjung)
+      </add>
+    </changelog>
+  </subsection>
+  <subsection name="Catalina">
+    <changelog>
+      <fix>
+        Protect initialization of <code>ResourceLinkFactory</code> when
+        running with a SecurityManager. (kkolinko)
+      </fix>
+      <fix>
+        Correct a thread safety issue in the filtering of session attributes
+        based on the implementing class name of the value object. (markt)
+      </fix>
+      <fix>
+        Fix class loader decision on the delegation for class loading and
+        resource lookup and make it faster too. (rjung)
+      </fix>
+      <fix>
+        <bug>58768</bug>: Log a warning if a redirect fails because of an
+        invalid location. (markt)
+      </fix>
+      <scode>
+        <bug>58827</bug>: Remove remains of JSR-77 implementation. (markt)
+      </scode>
+      <fix>
+        <bug>58946</bug>: Ensure that the request parameter map remains
+        immutable when processing via a RequestDispatcher. (markt)
+      </fix>
+      <fix>
+        <bug>58905</bug>: Ensure that <code>Tomcat.silence()</code> silences the
+        correct logger and respects the current setting. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Coyote">
+    <changelog>
+      <fix>
+        Correct a regression in the connector refactoring in 9.0.0.M2 that broke
+        TLS support for the APR/native connector. (remm)
+      </fix>
+      <fix>
+        Correct an NPE when listing the enabled ciphers (e.g. via the Manager
+        web application) for a TLS enabled APR/native connector. (markt)
+      </fix>
+      <add>
+        New configuration option <code>ajpFlush</code> for the AJP connectors
+        to disable the sending of AJP flush packets. (rjung)
+      </add>
+      <fix>
+        Handle the case in the NIO connector where the required TLS buffer sizes
+        increase after the connection has been initiated. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.0.M2 (markt)" rtext="not released">
+  <subsection name="Catalina">
+    <changelog>
+      <scode>
+        Refactor creation of <code>MapperListener</code> to ensure that the
+        <code>Mapper</code> used is the <code>Mapper</code> associated with the
+        <code>Service</code> for which the listener was created. (markt)
+      </scode>
+      <add>
+        Move the functionality that provides redirects for context roots and
+        directories where a trailing <code>/</code> is added from the Mapper to
+        the <code>DefaultServlet</code>. This enables such requests to be
+        processed by any configured Valves and Filters before the redirect is
+        made. This behaviour is configurable via the
+        <code>mapperContextRootRedirectEnabled</code> and
+        <code>mapperDirectoryRedirectEnabled</code> attributes of the Context
+        which may be used to restore the previous behaviour. (markt)
+      </add>
+      <scode>
+        Refactor <code>Service.getContainer()</code> to return an
+        <code>Engine</code> rather than a <code>Container</code>. (markt)
+      </scode>
+      <fix>
+        <bug>34319</bug>: Only load those keys in <code>StoreBase.processExpire</code>
+        from JDBCStore, that are old enough, to be expired. Based on a patch
+        by Tom Anderson. (fschumacher)
+      </fix>
+      <add>
+        <bug>56917</bug>: As per RFC7231 (HTTP/1.1), allow HTTP/1.1 and later
+        redirects to use relative URIs. This is controlled by a new attribute
+        <code>useRelativeRedirects</code> on the <strong>Context</strong> and
+        defaults to <code>true</code>. (markt)
+      </add>
+      <fix>
+        <bug>58629</bug>: Allow an embedded Tomcat instance to start when the
+        <code>Service</code> has no <code>Engine</code> configured. (markt)
+      </fix>
+      <fix>
+        Correctly notify the MapperListener associated with a Service if the
+        Engine for that Service is changed. (markt)
+      </fix>
+      <add>
+        Make a web application's CredentialHandler available through a context
+        attribute. This allows a web application to use the same algorithm
+        for validating or generating new stored credentials from cleartext
+        ones. (schultz)
+      </add>
+      <fix>
+        <bug>58635</bug>: Enable break points to be set within agent code when
+        running Tomcat with a Java agent. Based on a patch by Huxing Zhang.
+        (markt)
+      </fix>
+      <fix>
+        Fixed potential NPE in <code>HostConfig</code> while deploying an
+        application. Issue reported by coverity scan. (violetagg)
+      </fix>
+      <fix>
+        <bug>58655</bug>: Fix an <code> IllegalStateException</code> when
+        calling <code>HttpServletResponse.sendRedirect()</code> with the
+        <code>RemoteIpFilter</code>. This was caused by trying to correctly
+        generate the absolute URI for the redirect. With the fix for
+        <bug>56917</bug>, redirects may now be relative making the
+        <code>sendRedirect()</code> implementation for the
+        <code>RemoteIpFilter</code> much simpler. This also addresses issues
+        where the redirect may not have behaved as expected when redirecting
+        from http to https to from https to http. (markt)
+      </fix>
+      <fix>
+        <bug>58657</bug>: Exceptions in a Servlet 3.1 <code>ReadListener</code>
+        or <code>WriteListener</code> do not need to be immediately fatal to the
+        connection. Allow an error response to be written. (markt)
+      </fix>
+      <fix>
+        Correct implementation of
+        <code>validateClientProvidedNewSessionId</code> so client provided
+        session IDs may be rejected if validation is enabled. (markt)
+      </fix>
+      <fix>
+        <bug>58701</bug>: Reset the <code>instanceInitialized</code> field in
+        <code>StandardWrapper</code> when unloading a Servlet so that a new
+        instance may be correctly initialized. (markt)
+      </fix>
+      <update>
+        Add a new flag <code>aprPreferred</code> to the Apr listener. if set to
+        <code>false</code>, when using the connector defaults, it will use
+        NIO + OpenSSL if tomcat-native is available, rather than the APR
+        connector. (remm)
+      </update>
+      <fix>
+        Add path parameter handling to
+        <code>HttpServletRequest.getContextPath()</code>. This is a follow-up to
+        the fix for <bug>57215</bug>. (markt)
+      </fix>
+      <fix>
+        <bug>58692</bug>: Make <code>StandardJarScanner</code> more robust. Log
+        a warning if a class path entry cannot be scanned rather than triggering
+        the failure of the web application. Includes a test case written by
+         Derek Abdine. (markt)
+      </fix>
+      <fix>
+        <bug>58702</bug>: Ensure an access log entry is generated if the client
+        aborts the connection. (markt)
+      </fix>
+      <fix>
+        Fixed various issues reported by Findbugs. (violetagg)
+      </fix>
+      <fix>
+        <bug>58735</bug>: Add support for the <code>X-XSS-Protection</code>
+        header to the <code>HttpHeaderSecurityFilter</code>. Patch provided by
+        Jacopo Cappellato. (markt)
+      </fix>
+      <fix>
+        Add the <code>StatusManagerServlet</code> to the list of Servlets that
+        can only be loaded by privileged applications. (markt)
+      </fix>
+      <fix>
+        Simplify code and fix messages in
+        <code>org.apache.catalina.core.DefaultInstanceManager</code> class.
+        (kkolinko)
+      </fix>
+      <fix>
+        <bug>58751</bug>: Correctly handle the case where an
+        <code>AsyncListener</code> dispatches to a Servlet on an asynchronous
+        timeout and the Servlet uses <code>sendError()</code> to trigger an
+        error page. Includes a test case based on code provided by Andy
+        Wilkinson.(markt)
+      </fix>
+      <fix>
+        Ensure that the proper file encoding if specified will be used when
+        a readme file is served by DefaultServlet. (violetagg)
+      </fix>
+      <fix>
+        Fix declaration of <code>localPort</code> attribute of Connector MBean:
+        it is read-only. (kkolinko)
+      </fix>
+      <fix>
+        <bug>58766</bug>: Make skipping non-class files during annotation
+        scanning faster by checking the file name first. Improve debug logging.
+        (kkolinko)
+      </fix>
+      <fix>
+        <bug>58836</bug>: Correctly merge query string parameters when
+        processing a forwarded request where the target includes a query string
+        that contains a parameter with no value. (markt/kkolinko)
+      </fix>
+      <fix>
+        Make sure that shared Digester is reset in an unlikely error case
+        in <code>HostConfig.deployWAR()</code>. (kkolinko)
+      </fix>
+      <add>
+        Extend the feature available in the cluster session manager
+        implementations that enables session attribute replication to be
+        filtered based on attribute name to all session manager implementations.
+        Note that configuration attribute name has changed from
+        <code>sessionAttributeFilter</code> to
+        <code>sessionAttributeNameFilter</code>. Apply the filter on load as
+        well as unload to ensure that configuration changes made while the web
+        application is stopped are applied to any persisted data. (markt)
+      </add>
+      <add>
+        Extend the session attribute filtering options to include filtering
+        based on the implementation class of the value and optional
+        <code>WARN</code> level logging if an attribute is filtered. These
+        options are available for all of the Manager implementations that ship
+        with Tomcat. When a <code>SecurityManager</code> is used filtering will
+        be enabled by default. (markt)
+      </add>
+      <scode>
+        Remove <code>distributable</code> and <code>maxInactiveInterval</code>
+        from the <code>Manager</code> interface because the attributes are never
+        used. The equivalent attributes from the <code>Context</code> always
+        take precedence. (markt)
+      </scode>
+      <fix>
+        <bug>58867</bug>: Improve checking on Host start for WAR files that have
+        been modified while Tomcat has stopped and re-expand them if
+        <code>unpackWARs</code> is <code>true</code>. (markt)
+      </fix>
+      <fix>
+        <bug>58900</bug>: Correctly undeploy symlinked resources and prevent an
+        infinite cycle of deploy / undeploy. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Coyote">
+    <changelog>
+      <fix>
+        <bug>58621</bug>: The certificate chain cannot be set using the main
+        certificate attribute, so restore the certificate chain property. (remm)
+      </fix>
+      <fix>
+        Allow a new SSL config type where a connector can use either JSSE or
+        OpenSSL. Both could be allowed, but it would likely create support
+        issues. This type is used by the OpenSSL implementation for NIOx. (remm)
+      </fix>
+      <fix>
+        Improve upgrade context classloader handling by using Context.bind and
+        unbind. (remm)
+      </fix>
+      <add>
+        Improve OpenSSL keystore/truststore configuration by using the code
+        from the JSSE implementation. (remm, jfclere)
+      </add>
+      <fix>
+        Fix a potential loop when a client drops the connection unexpectedly.
+        (markt)
+      </fix>
+      <add>
+        OpenSSL renegotiation support for client certificate authentication.
+        (remm)
+      </add>
+      <fix>
+        Fix NIO connector renegotiation. (remm)
+      </fix>
+      <fix>
+        <bug>58659</bug>: Fix a potential deadlock during HTTP/2 processing when
+        the connection window size is limited. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Jasper">
+    <changelog>
+      <fix>
+        <bug>57136#c25</bug>: Change default value of
+        <code>quoteAttributeEL</code> setting in Jasper to be <code>true</code>
+        for better compatibility with other implementations and older versions
+        of Tomcat. Add command line option <code>-no-quoteAttributeEL</code> in
+        JspC. (kkolinko)
+      </fix>
+      <fix>
+        Fix handling of missing messages in
+        <code>org.apache.el.util.MessageFactory</code>. (violetagg)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Cluster">
+    <changelog>
+      <fix>
+        Enable an explicit configuration of local member in the static cluster
+        membership. (kfujino)
+      </fix>
+      <fix>
+        Fix potential integer overflow in <code>DeltaSession</code>.
+        Reported by coverity scan. (fschumacher)
+      </fix>
+      <fix>
+        In order to avoid that the heartbeat thread and the background thread to
+        run <code>Channel.heartbeat</code> simultaneously, if
+        <code>heartbeatBackgroundEnabled</code> of <code>SimpleTcpCluster</code>
+        set to <code>true</code>, ensure that the heartbeat thread does not
+        start. (kfujino)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="WebSocket">
+    <changelog>
+      <add>
+        <bug>55006</bug>: The WebSocket client now honors the
+        <code>java.net.java.net.ProxySelector</code> configuration (using the
+        HTTP type) when establishing WebSocket connections to servers. Based on
+        a patch by Niki Dokovski. (markt)
+      </add>
+      <fix>
+        <bug>58624</bug>: Correct a potential deadlock if the WebSocket
+        connection is closed when a message write is in progress. (markt)
+      </fix>
+      <fix>
+        <bug>57489</bug>: Ensure <code>onClose()</code> is called when a
+        WebSocket connection is closed even if the sending of the close message
+        fails. Includes test cases by Barry Coughlan. (markt)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Web Applications">
+    <changelog>
+      <fix>
+        <bug>58631</bug>: Correct the continuation character use in the Windows
+        Service How-To page of the documentation web application. (markt)
+      </fix>
+      <fix>
+        Correct the SSL documentation for deprecated attributes to point to the
+        correct, new location for attributes related to individual certificates.
+        (markt)
+      </fix>
+      <fix>
+        Correct some typos in the JNDI resources How-To. (markt)
+      </fix>
+      <fix>
+        Don't create session unnecessarily in the Manager application. (markt)
+      </fix>
+      <fix>
+        Don't create session unnecessarily in the Host Manager application.
+        (markt)
+      </fix>
+      <fix>
+        <bug>58723</bug>: Clarify documentation and error messages for the text
+        interface of the manager to make clear that version must be used with
+        path when referencing contexts deployed using parallel deployment.
+        (markt)
+      </fix>
+      <add>
+        Document <code>test.threads</code> option in BUILDING.txt. (kkolinko)
+      </add>
+    </changelog>
+  </subsection>
+  <subsection name="Tribes">
+    <changelog>
+      <fix>
+        Ensure that the static member is registered to the add suspect list even
+        if the static member that is registered to the remove suspect list has
+        disappeared. (kfujino)
+      </fix>
+      <fix>
+        When using a static cluster, add the members that have been cached in
+        the membership service to the map members list in order to ensure that
+        the map member is a static member. (kfujino)
+      </fix>
+      <fix>
+        Add support for the startup notification of local members in the static
+        cluster. (kfujino)
+      </fix>
+      <fix>
+        Ignore the unnecessary member remove operation from different domain.
+        (kfujino)
+      </fix>
+      <fix>
+        Add support for the shutdown notification of local members in the static
+        cluster. (kfujino)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="jdbc-pool">
+    <changelog>
+      <fix>
+        Correct evaluation of system property
+        <code>org.apache.tomcat.jdbc.pool.onlyAttemptCurrentClassLoader</code>.
+        It was basically ignored before. Reported by coverity scan. (fschumacher)
+      </fix>
+      <fix>
+        Fix potential integer overflow in <code>ConnectionPool</code> and
+        <code>PooledConnection</code>. Reported by coverity scan. (fschumacher)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Other">
+    <changelog>
+      <update>
+        Update optional Checkstyle library to 6.14.1. (kkolinko)
+      </update>
+      <update>
+        Update the packaged version of the Tomcat Native Library to 1.2.4 to
+        pick up the Windows binaries that are based on OpenSSL 1.0.2e and APR
+        1.5.1. (markt)
+      </update>
+      <update>
+        Update the NSIS Installer used to build the Windows Installers to
+        version 2.50. (markt/kkolinko)
+      </update>
+      <update>
+        Update the internal fork of Commons BCEL to r1725718 to align with the
+        refactoring for BCEL 6, the next major BCEL release. (markt)
+      </update>
+      <update>
+        Update the internal fork of Commons DBCP 2 to r1725730 (2.1.1 plus
+        additional fixes). (markt)
+      </update>
+      <update>
+        Update the internal fork of Commons Pool 2 to r1725738 (2.4.2 plus
+        additional fixes). (markt)
+      </update>
+      <update>
+        Update the internal fork of Commons Codec to r1725746 (1.9 plus
+        additional fixes). (markt)
+      </update>
+    </changelog>
+  </subsection>
+</section>
+<section name="Tomcat 9.0.0.M1 (markt)" rtext="2015-11-17">
+  <subsection name="General">
+    <changelog>
+      <add>
+        Make Java 8 the minimum required version to build and run Tomcat 9.
+        (markt)
+      </add>
+      <update>
+        Remove support for Comet. (markt)
+      </update>
+      <update>
+        Tighten up the default file permissions for the <code>.tar.gz</code>
+        distribution so no files or directories are world readable by default.
+        Configure Tomcat to run with a default umask of <code>0027</code> which
+        may be overridden by setting <code>UMASK</code> in
+        <code>setenv.sh</code>. (markt)
+      </update>
+      <update>
+        Remove native code (Windows Service Wrapper, APR/native connector)
+        support for Windows Itanium. (markt)
+      </update>
+    </changelog>
+  </subsection>
+  <subsection name="Catalina">
+    <changelog>
+      <update>
+        The default HTTP cookie parser has been changed to
+        <code>org.apache.tomcat.util.http.Rfc6265CookieProcessor</code>. (markt)
+      </update>
+    </changelog>
+  </subsection>
+  <subsection name="Coyote">
+    <changelog>
+      <update>
+        Remove support for the HTTP BIO and AJP BIO connectors. (markt)
+      </update>
+      <scode>
+        Refactor HTTP upgrade and AJP implementations to reduce duplication.
+        (markt)
+      </scode>
+      <add>
+        Add support for HPACK header encoding and decoding, contributed
+        by Stuart Douglas. (remm)
+      </add>
+      <add>
+        <bug>57108</bug>: Add support for Server Name Indication (SNI). There
+        has been significant changes to the SSL configuration in server.xml to
+        support this. (markt)
+      </add>
+      <add>
+        Add SSL engine for JSSE backed by OpenSSL. Includes ALPN support.
+        Based on code contributed by Numa de Montmollin and derived from code
+        developed by Twitter and Netty. (remm)
+      </add>
+      <fix>
+        RFC 7230 states that clients should ignore reason phrases in HTTP/1.1
+        response messages. Since the reason phrase is optional, Tomcat no longer
+        sends it. As a result the system property
+        <code>org.apache.coyote.USE_CUSTOM_STATUS_MSG_IN_HEADER</code> is no
+        longer used and has been removed. (markt)
+      </fix>
+      <update>
+        The minimum required Tomcat Native version has been increased to 1.2.2.
+        The 1.2.x branch includes ALPN and SNI support which are required for
+        HTTP/2. (markt)
+      </update>
+      <add>
+        Add support for HTTP/2 including server push. (markt)
+      </add>
+    </changelog>
+  </subsection>
+  <subsection name="Tribes">
+    <changelog>
+      <fix>
+        Clarify the handling of Copy message and Copy nodes. (kfujino)
+      </fix>
+    </changelog>
+  </subsection>
+  <subsection name="Other">
+    <changelog>
+      <add>
+        Support the use of the <code>threads</code> attribute on Ant&apos;s
+        junit task. Note that using this with a value of greater than one will
+        disable Cobertura code coverage. (markt)
+      </add>
+    </changelog>
+  </subsection>
+</section>
+</body>
+</document>


### PR DESCRIPTION
…ttribute with multiple EL parts breaks function lookup

Fix https://bz.apache.org/bugzilla/show_bug.cgi?id=61854
When using sets and/or maps in EL expressions, ensure that Jasper correctly parses the expression.
Patch provided by Ricardo Martin Camarero.

git-svn-id: https://svn.apache.org/repos/asf/tomcat/trunk@1817298 13f79535-47bb-0310-9956-ffa450edef68

upstream: https://github.com/undertow-io/jastow/pull/36
https://issues.jboss.org/browse/WFLY-6263
https://issues.jboss.org/browse/JBEAP-13924
https://issues.jboss.org/browse/JBEAP-13925
https://issues.jboss.org/browse/JBEAP-13897