### PR TITLE
[UNDERTOW-1398] Include jsp from a taglib throws exception if path not normalized

### DIFF
--- a/src/main/java/org/apache/jasper/compiler/ParserController.java
+++ b/src/main/java/org/apache/jasper/compiler/ParserController.java
@@ -21,6 +21,7 @@ import static org.apache.jasper.JasperMessages.MESSAGES;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.file.Paths;
 import java.util.Stack;
 
 import org.apache.jasper.JasperException;
@@ -501,6 +502,7 @@ class ParserController implements TagConstants {
         boolean isAbsolute = fileName.startsWith("/");
         fileName = isAbsolute ? fileName
                 : baseDirStack.peek() + fileName;
+	fileName = Paths.get(fileName).normalize().toString();
         String baseDir =
             fileName.substring(0, fileName.lastIndexOf("/") + 1);
         baseDirStack.push(baseDir);


### PR DESCRIPTION
Fix for normalize filename in ParserController
JBEAP (7.1.x): https://issues.jboss.org/browse/JBEAP-15250
Upstream: https://issues.jboss.org/browse/UNDERTOW-1398
Upstream PR: https://github.com/undertow-io/jastow/pull/30