### PR TITLE
JBEAP-10134 continuation: Windows fix for normalize

### DIFF
--- a/src/main/java/org/apache/jasper/compiler/ParserController.java
+++ b/src/main/java/org/apache/jasper/compiler/ParserController.java
@@ -21,7 +21,9 @@ import static org.apache.jasper.JasperMessages.MESSAGES;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Iterator;
 import java.util.Stack;
 
 import org.apache.jasper.JasperException;
@@ -513,6 +515,21 @@ class ParserController implements TagConstants {
     }
 
     /*
+     * Normalizes the filename. Done this way to always use "/"
+     * as the separator.
+     */
+    private String normalizeFileName(String inFileName) {
+        Path path = Paths.get(inFileName).normalize();
+        StringBuilder sb = new StringBuilder();
+        // it's always absolute
+        Iterator<Path> i = path.iterator();
+        while (i.hasNext()) {
+            sb.append("/").append(i.next().toString());
+        }
+        return sb.toString();
+    }
+
+    /*
      * Resolve the name of the file and update baseDirStack() to keep track of
      * the current base directory for each included file.
      * The 'root' file is always an 'absolute' path, so no need to put an
@@ -523,7 +540,7 @@ class ParserController implements TagConstants {
         boolean isAbsolute = fileName.startsWith("/");
         fileName = isAbsolute ? fileName
                 : baseDirStack.peek() + fileName;
-	fileName = Paths.get(fileName).normalize().toString();
+        fileName = normalizeFileName(fileName);
         String baseDir =
             fileName.substring(0, fileName.lastIndexOf("/") + 1);
         baseDirStack.push(baseDir);


### PR DESCRIPTION
The PR #30 to fix JBEAP-10134 introduced a regression on Windows. The normalization of the file name in windows returns paths with "\\" separator and that's not good. So I think the normalization should be re-thought. I did this simple solution that mixes Path and the iterator. But it's just an idea (I spent some time trying to figure out how to normalize the path, but didn't find a perfect solution), you can re-think this and see if you reach something better.