### PR TITLE
Patch UNDERTOW-1473

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 
         <version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec>1.0.1.Final</version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec>
         <version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec>1.0.2.Final</version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec>
-        <version.org.eclipse.jdt.core.compiler.ecj>4.6.1</version.org.eclipse.jdt.core.compiler.ecj>
+        <version.org.eclipse.jdt.ecj>3.16.0</version.org.eclipse.jdt.ecj>
         <version.io.undertow>1.4.20.Final</version.io.undertow>
         <version.org.apache.httpcomponents>4.5.3</version.org.apache.httpcomponents>
         <version.junit>4.12</version.junit>
@@ -161,10 +161,10 @@
         </dependency>
 
         <dependency>
-            <groupId>org.eclipse.jdt.core.compiler</groupId>
-            <artifactId>ecj</artifactId>
-            <version>${version.org.eclipse.jdt.core.compiler.ecj}</version>
-        </dependency>
+          <groupId>org.eclipse.jdt</groupId>
+          <artifactId>ecj</artifactId>
+          <version>${version.org.eclipse.jdt.ecj}</version>
+      </dependency>
 
         <dependency>
             <groupId>io.undertow</groupId>

--- a/src/main/java/org/apache/jasper/compiler/JDTCompiler.java
+++ b/src/main/java/org/apache/jasper/compiler/JDTCompiler.java
@@ -317,10 +317,18 @@ public class JDTCompiler extends org.apache.jasper.compiler.Compiler {
             } else if(opt.equals("1.8")) {
                 settings.put(CompilerOptions.OPTION_Source,
                         CompilerOptions.VERSION_1_8);
-            } else if(opt.equals("1.9")) {
+            // Version format changed from Java 9 onwards.
+            // Keeping support for old format to prevent breaking code
+            } else if(opt.equals("9") || opt.equals("1.9")) {
                 settings.put(CompilerOptions.OPTION_Source,
-                             CompilerOptions.VERSION_1_9);
-            } else {
+                             CompilerOptions.VERSION_9);
+            } else if(opt.equals("10")) {
+                settings.put(CompilerOptions.OPTION_Source,
+                             CompilerOptions.VERSION_10);
+            } else if(opt.equals("11")) {
+                settings.put(CompilerOptions.OPTION_Source,
+                             CompilerOptions.VERSION_11);
+            }  else {
                 JasperLogger.COMPILER_LOGGER.unknownSourceJvm(opt);
                 settings.put(CompilerOptions.OPTION_Source,
                         CompilerOptions.VERSION_1_8);
@@ -366,11 +374,23 @@ public class JDTCompiler extends org.apache.jasper.compiler.Compiler {
                         CompilerOptions.VERSION_1_8);
                 settings.put(CompilerOptions.OPTION_Compliance,
                         CompilerOptions.VERSION_1_8);
-            } else if(opt.equals("1.9")) {
+            // Version format changed from Java 9 onwards.
+            // Keeping support for old format to prevent breaking code
+            } else if(opt.equals("9") || opt.equals("1.9")) {
                 settings.put(CompilerOptions.OPTION_TargetPlatform,
-                             CompilerOptions.VERSION_1_9);
+                             CompilerOptions.VERSION_9);
                 settings.put(CompilerOptions.OPTION_Compliance,
-                        CompilerOptions.VERSION_1_9);
+                        CompilerOptions.VERSION_9);
+            } else if(opt.equals("10")) {
+                settings.put(CompilerOptions.OPTION_TargetPlatform,
+                        CompilerOptions.VERSION_10);
+                settings.put(CompilerOptions.OPTION_Compliance,
+                        CompilerOptions.VERSION_10);
+            } else if(opt.equals("11")) {
+                settings.put(CompilerOptions.OPTION_TargetPlatform,
+                        CompilerOptions.VERSION_11);
+                settings.put(CompilerOptions.OPTION_Compliance,
+                        CompilerOptions.VERSION_11);
             } else {
                 log.warn("Unknown target VM " + opt + " ignored.");
                 settings.put(CompilerOptions.OPTION_TargetPlatform,


### PR DESCRIPTION
Adding support to jsp-config source-vm and target-vm for JDK version 9, 10 and 11. 

It requires an update of the ecj dependency from GroupID org.eclipse.jdt.core.compiler version 4.6.1 (which dates from October 2016) to GroupId org.eclipse.jdt version 3.16.0 (which dates from December 2018)