### PR TITLE
Fix UNDERTOW-1632: Remove unneccessary cast to HashMap

### DIFF
--- a/src/main/java/org/apache/jasper/compiler/JspConfig.java
+++ b/src/main/java/org/apache/jasper/compiler/JspConfig.java
@@ -20,8 +20,8 @@ package org.apache.jasper.compiler;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Vector;
 import javax.servlet.ServletContext;
 import javax.servlet.descriptor.JspConfigDescriptor;
@@ -82,8 +82,8 @@ public class JspConfig {
                     }
 
         jspProperties = new Vector<>();
-        HashMap<String, org.apache.jasper.deploy.JspPropertyGroup> jspPropertyGroups =
-                                (HashMap<String, org.apache.jasper.deploy.JspPropertyGroup>)
+        Map<String, org.apache.jasper.deploy.JspPropertyGroup> jspPropertyGroups =
+                                (Map<String, org.apache.jasper.deploy.JspPropertyGroup>)
                                 ctxt.getAttribute(Constants.JSP_PROPERTY_GROUPS);
 
         for (String key : jspPropertyGroups.keySet()) {


### PR DESCRIPTION
`JspServletBuilder.setupDeployment()` takes a `Map` as it's second argument, but line 85 of `org.apache.jasper.compiler.JspConfig` randomly casts this argument to a `HashMap`. The unnecessary cast should be removed. 

The bug probably hasn't been found because most examples available online pass an empty `HashMap` to `JspServletBuilder.setupDeployment()`.

The JIRA link is https://issues.redhat.com/browse/UNDERTOW-1632.