### PR TITLE
[UNDERTOW-1768] Optimize jastow constants for javax->jakarta transfor…

### DIFF
--- a/src/main/java/org/apache/jasper/compiler/Generator.java
+++ b/src/main/java/org/apache/jasper/compiler/Generator.java
@@ -433,7 +433,7 @@ class Generator {
     private void generateInit() {
 
         if (ctxt.isTagFile()) {
-            out.printil("private void _jspInit(javax.servlet.ServletConfig config) {");
+            printilThreePart(out, "private void _jspInit(", "javax.servlet.ServletConfig", " config) {");
         } else {
             out.printil("public void _jspInit() {");
         }
@@ -528,8 +528,8 @@ class Generator {
      * preamble generation)
      */
     private void genPreambleStaticInitializers() {
-        out.printil("private static final javax.servlet.jsp.JspFactory _jspxFactory =");
-        out.printil("        javax.servlet.jsp.JspFactory.getDefaultFactory();");
+        printilThreePart(out, "private static final ", "javax.servlet.jsp.JspFactory", " _jspxFactory =");
+        printilThreePart(out, "        ", "javax.servlet.jsp.JspFactory", ".getDefaultFactory();");
         out.println();
 
         // Static data for getDependants()
@@ -621,7 +621,7 @@ class Generator {
             }
             out.println();
         }
-        out.printin("private javax.el.ExpressionFactory ");
+        printinThreePart(out, "private ", "javax.el.ExpressionFactory", " ");
         out.print(VAR_EXPRESSIONFACTORY);
         out.println(";");
         out.printin("private org.apache.tomcat.InstanceManager ");
@@ -687,7 +687,7 @@ class Generator {
         out.printin("                 org.apache.jasper.runtime.JspSourceImports");
         if (!pageInfo.isThreadSafe()) {
             out.println(",");
-            out.printin("                 javax.servlet.SingleThreadModel");
+            printinTwoPart(out, "                 ", "javax.servlet.SingleThreadModel");
         }
         out.println(" {");
         out.pushIndent();
@@ -707,8 +707,8 @@ class Generator {
         // Now the service method
         out.printin("public void ");
         out.print(serviceMethodName);
-        out.println("(final javax.servlet.http.HttpServletRequest request, final javax.servlet.http.HttpServletResponse response)");
-        out.println("        throws java.io.IOException, javax.servlet.ServletException {");
+        printlnMultiPart(out, "(final ", "javax.servlet.http.HttpServletRequest", " request, final ", "javax.servlet.http.HttpServletResponse", " response)");
+        printlnThreePart(out, "        throws java.io.IOException, ", "javax.servlet.ServletException", " {");
 
         out.pushIndent();
         out.println();
@@ -717,7 +717,7 @@ class Generator {
         if (!pageInfo.isErrorPage()) {
             out.println("final java.lang.String _jspx_method = request.getMethod();");
             out.print("if (!\"GET\".equals(_jspx_method) && !\"POST\".equals(_jspx_method) && !\"HEAD\".equals(_jspx_method) && ");
-            out.println("!javax.servlet.DispatcherType.ERROR.equals(request.getDispatcherType())) {");
+            printlnThreePart(out, "!", "javax.servlet.DispatcherType", ".ERROR.equals(request.getDispatcherType())) {");
             out.pushIndent();
             out.print("response.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, ");
             out.println("\"" + JasperMessages.MESSAGES.forbiddenHttpMethod()+ "\");");
@@ -728,27 +728,27 @@ class Generator {
         }
 
         // Local variable declarations
-        out.printil("final javax.servlet.jsp.PageContext pageContext;");
+        printilThreePart(out, "final ", "javax.servlet.jsp.PageContext", " pageContext;");
 
         if (pageInfo.isSession())
-            out.printil("javax.servlet.http.HttpSession session = null;");
+            printilTwoPart(out, "javax.servlet.http.HttpSession", " session = null;");
 
         if (pageInfo.isErrorPage()) {
             out.printil("java.lang.Throwable exception = org.apache.jasper.runtime.JspRuntimeLibrary.getThrowable(request);");
             out.printil("if (exception != null) {");
             out.pushIndent();
-            out.printil("response.setStatus(javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR);");
+            printilThreePart(out, "response.setStatus(", "javax.servlet.http.HttpServletResponse", ".SC_INTERNAL_SERVER_ERROR);");
             out.popIndent();
             out.printil("}");
         }
 
-        out.printil("final javax.servlet.ServletContext application;");
-        out.printil("final javax.servlet.ServletConfig config;");
-        out.printil("javax.servlet.jsp.JspWriter out = null;");
+        printilThreePart(out, "final ", "javax.servlet.ServletContext", " application;");
+        printilThreePart(out, "final ", "javax.servlet.ServletConfig", " config;");
+        printilTwoPart(out, "javax.servlet.jsp.JspWriter", " out = null;");
         out.printil("final java.lang.Object page = this;");
 
-        out.printil("javax.servlet.jsp.JspWriter _jspx_out = null;");
-        out.printil("javax.servlet.jsp.PageContext _jspx_page_context = null;");
+        printilTwoPart(out, "javax.servlet.jsp.JspWriter", " _jspx_out = null;");
+        printilTwoPart(out, "javax.servlet.jsp.PageContext", " _jspx_page_context = null;");
         out.println();
 
         declareTemporaryScriptingVars(page);
@@ -1136,7 +1136,7 @@ class Generator {
             printParams(n, pageParam, page.isLiteral());
             out.println(");");
             if (isTagFile || isFragment) {
-                out.printil("throw new javax.servlet.jsp.SkipPageException();");
+                printilThreePart(out, "throw new ", "javax.servlet.jsp.SkipPageException" , "();");
             } else {
                 out.printil((methodNesting > 0) ? "return true;" : "return;");
             }
@@ -1428,7 +1428,7 @@ class Generator {
                     out.popIndent();
                     out.printil("} catch (java.lang.Exception exc) {");
                     out.pushIndent();
-                    out.printin("throw new javax.servlet.ServletException(");
+                    printinThreePart(out,"throw new ", "javax.servlet.ServletException", "(");
                     out.print("\"Cannot create bean of class \" + ");
                     out.print(binaryName);
                     out.println(", exc);");
@@ -1783,11 +1783,13 @@ class Generator {
                 out.print(tagMethod);
                 out.print("(");
                 if (parent != null) {
-                    out.print("javax.servlet.jsp.tagext.JspTag ");
+                    out.print("javax.servlet.jsp.tagext.JspTag");
+                    out.print(" ");
                     out.print(parent);
                     out.print(", ");
                 }
-                out.print("javax.servlet.jsp.PageContext _jspx_page_context");
+                out.print("javax.servlet.jsp.PageContext");
+                out.print(" _jspx_page_context");
                 if (pushBodyCountVar != null) {
                     out.print(", int[] ");
                     out.print(pushBodyCountVar);
@@ -1798,9 +1800,9 @@ class Generator {
 
                 // Initialize local variables used in this method.
                 if (!isTagFile) {
-                    out.printil("javax.servlet.jsp.PageContext pageContext = _jspx_page_context;");
+                    printilTwoPart(out, "javax.servlet.jsp.PageContext", " pageContext = _jspx_page_context;");
                 }
-                out.printil("javax.servlet.jsp.JspWriter out = _jspx_page_context.getOut();");
+                printilTwoPart(out, "javax.servlet.jsp.JspWriter", " out = _jspx_page_context.getOut();");
                 generateLocalVariables(out, n);
             }
 
@@ -2262,7 +2264,7 @@ class Generator {
             }
 
             // Restore EL context
-            out.printil("jspContext.getELContext().putContext(javax.servlet.jsp.JspContext.class,getJspContext());");
+            printilThreePart(out, "jspContext.getELContext().putContext(", "javax.servlet.jsp.JspContext", ".class,getJspContext());");
 
             n.setEndJavaLine(out.getJavaLine());
         }
@@ -2372,7 +2374,7 @@ class Generator {
             if (!n.hasEmptyBody()) {
                 out.printin("if (");
                 out.print(tagEvalVar);
-                out.println(" != javax.servlet.jsp.tagext.Tag.SKIP_BODY) {");
+                printlnThreePart(out, " != ", "javax.servlet.jsp.tagext.Tag", ".SKIP_BODY) {");
                 out.pushIndent();
 
                 // Declare NESTED scripting variables
@@ -2382,7 +2384,7 @@ class Generator {
                 if (n.implementsBodyTag()) {
                     out.printin("if (");
                     out.print(tagEvalVar);
-                    out.println(" != javax.servlet.jsp.tagext.Tag.EVAL_BODY_INCLUDE) {");
+                    printlnThreePart(out, " != ", "javax.servlet.jsp.tagext.Tag", ".EVAL_BODY_INCLUDE) {");
                     // Assume EVAL_BODY_BUFFERED
                     out.pushIndent();
                     out.printil("out = _jspx_page_context.pushBody();");
@@ -2394,7 +2396,7 @@ class Generator {
                         out.println("[0]++;");
                     }
                     out.printin(tagHandlerVar);
-                    out.println(".setBodyContent((javax.servlet.jsp.tagext.BodyContent) out);");
+                    printilThreePart(out, ".setBodyContent((", "javax.servlet.jsp.tagext.BodyContent", ") out);");
                     out.printin(tagHandlerVar);
                     out.println(".doInitBody();");
 
@@ -2467,7 +2469,7 @@ class Generator {
                     syncScriptingVars(n, VariableInfo.AT_BEGIN);
                     syncScriptingVars(n, VariableInfo.NESTED);
 
-                    out.printil("if (evalDoAfterBody != javax.servlet.jsp.tagext.BodyTag.EVAL_BODY_AGAIN)");
+                    printilThreePart(out, "if (evalDoAfterBody != ", "javax.servlet.jsp.tagext.BodyTag", ".EVAL_BODY_AGAIN)");
                     out.pushIndent();
                     out.printil("break;");
                     out.popIndent();
@@ -2481,7 +2483,7 @@ class Generator {
                 if (n.implementsBodyTag()) {
                     out.printin("if (");
                     out.print(tagEvalVar);
-                    out.println(" != javax.servlet.jsp.tagext.Tag.EVAL_BODY_INCLUDE) {");
+                    printlnThreePart(out, " != ", "javax.servlet.jsp.tagext.Tag", ".EVAL_BODY_INCLUDE) {");
                     out.pushIndent();
                     out.printil("out = _jspx_page_context.popBody();");
                     if (n.implementsTryCatchFinally()) {
@@ -2501,7 +2503,7 @@ class Generator {
 
             out.printin("if (");
             out.print(tagHandlerVar);
-            out.println(".doEndTag() == javax.servlet.jsp.tagext.Tag.SKIP_PAGE) {");
+            printlnThreePart(out, ".doEndTag() == ", "javax.servlet.jsp.tagext.Tag", ".SKIP_PAGE) {");
             out.pushIndent();
             if (!n.implementsTryCatchFinally()) {
                 if (isPoolingEnabled && !(n.implementsJspIdConsumer())) {
@@ -2516,7 +2518,7 @@ class Generator {
                 }
             }
             if (isTagFile || isFragment) {
-                out.printil("throw new javax.servlet.jsp.SkipPageException();");
+                printilThreePart(out, "throw new ", "javax.servlet.jsp.SkipPageException", "();");
             } else {
                 out.printil((methodNesting > 0) ? "return true;" : "return;");
             }
@@ -3138,19 +3140,19 @@ class Generator {
             if (isTagFile && parent == null) {
                 out.printin(tagHandlerVar);
                 out.print(".setParent(");
-                out.print("new javax.servlet.jsp.tagext.TagAdapter(");
-                out.print("(javax.servlet.jsp.tagext.SimpleTag) this ));");
+                printThreePart(out, "new ", "javax.servlet.jsp.tagext.TagAdapter", "(");
+                printThreePart(out, "(", "javax.servlet.jsp.tagext.SimpleTag", ") this ));");
             } else if (!simpleTag) {
                 out.printin(tagHandlerVar);
                 out.print(".setParent(");
                 if (parent != null) {
                     if (isSimpleTagParent) {
-                        out.print("new javax.servlet.jsp.tagext.TagAdapter(");
-                        out.print("(javax.servlet.jsp.tagext.SimpleTag) ");
+                        printThreePart(out, "new ", "javax.servlet.jsp.tagext.TagAdapter", "(");
+                        printThreePart(out, "(", "javax.servlet.jsp.tagext.SimpleTag", ") ");
                         out.print(parent);
                         out.println("));");
                     } else {
-                        out.print("(javax.servlet.jsp.tagext.Tag) ");
+                        printThreePart(out, "(", "javax.servlet.jsp.tagext.Tag", ") ");
                         out.print(parent);
                         out.println(");");
                     }
@@ -3370,9 +3372,9 @@ class Generator {
                 if (!templateTextOptimization) {
                     out.printil("out = _jspx_page_context.pushBody();");
                     visitBody(n);
-                    out.printil("java.lang.String " + varName + " = "
-                            + "((javax.servlet.jsp.tagext.BodyContent)"
-                            + "out).getString();");
+                    printilMultiPart(out, "java.lang.String ", varName, " = ",
+                            "((", "javax.servlet.jsp.tagext.BodyContent", ")",
+                            "out).getString();");
                     out.printil("out = _jspx_page_context.popBody();");
                 }
             } else {
@@ -3398,8 +3400,7 @@ class Generator {
                 String tagHandlerVar) throws JasperException {
             String varName = n.getTemporaryVariableName();
 
-            out.printin("javax.servlet.jsp.tagext.JspFragment " + varName
-                    + " = ");
+            printinMultiPart(out,"javax.servlet.jsp.tagext.JspFragment", " ", varName, " = ");
             generateJspFragment(n, tagHandlerVar);
             out.println(";");
 
@@ -3425,15 +3426,15 @@ class Generator {
         }
 
         if (ci.hasUseBean()) {
-            out.printil("javax.servlet.http.HttpSession session = _jspx_page_context.getSession();");
-            out.printil("javax.servlet.ServletContext application = _jspx_page_context.getServletContext();");
+            printilTwoPart(out, "javax.servlet.http.HttpSession", " session = _jspx_page_context.getSession();");
+            printilTwoPart(out, "javax.servlet.ServletContext", " application = _jspx_page_context.getServletContext();");
         }
         if (ci.hasUseBean() || ci.hasIncludeAction() || ci.hasSetProperty()
                 || ci.hasParamAction()) {
-            out.printil("javax.servlet.http.HttpServletRequest request = (javax.servlet.http.HttpServletRequest)_jspx_page_context.getRequest();");
+            printilMultiPart(out, "javax.servlet.http.HttpServletRequest", " request = (", "javax.servlet.http.HttpServletRequest", ")_jspx_page_context.getRequest();");
         }
         if (ci.hasIncludeAction()) {
-            out.printil("javax.servlet.http.HttpServletResponse response = (javax.servlet.http.HttpServletResponse)_jspx_page_context.getResponse();");
+            printilMultiPart(out, "javax.servlet.http.HttpServletResponse", " response = (", "javax.servlet.http.HttpServletResponse", ")_jspx_page_context.getResponse();");
         }
     }
 
@@ -3472,7 +3473,7 @@ class Generator {
         out.popIndent();
         out.printil("} catch (java.lang.Throwable t) {");
         out.pushIndent();
-        out.printil("if (!(t instanceof javax.servlet.jsp.SkipPageException)){");
+        printilThreePart(out, "if (!(t instanceof ", "javax.servlet.jsp.SkipPageException", ")){");
         out.pushIndent();
         out.printil("out = _jspx_out;");
         out.printil("if (out != null && out.getBufferSize() != 0)");
@@ -3633,11 +3634,11 @@ class Generator {
         // Generate class declaration
         out.printin("public final class ");
         out.println(className);
-        out.printil("    extends javax.servlet.jsp.tagext.SimpleTagSupport");
+        printilTwoPart(out, "    extends ", "javax.servlet.jsp.tagext.SimpleTagSupport");
         out.printin("    implements org.apache.jasper.runtime.JspSourceDependent");
         if (tagInfo.hasDynamicAttributes()) {
             out.println(",");
-            out.printin("               javax.servlet.jsp.tagext.DynamicAttributes");
+            printinTwoPart(out, "               ", "javax.servlet.jsp.tagext.DynamicAttributes");
         }
         out.println(" {");
         out.println();
@@ -3651,7 +3652,7 @@ class Generator {
         // Static initializations here
         genPreambleStaticInitializers();
 
-        out.printil("private javax.servlet.jsp.JspContext jspContext;");
+        printilThreePart(out, "private ", "javax.servlet.jsp.JspContext", " jspContext;");
 
         // Declare writer used for storing result of fragment/body invocation
         // if 'varReader' or 'var' attribute is specified
@@ -3671,7 +3672,7 @@ class Generator {
         genPreambleMethods();
 
         // Now the doTag() method
-        out.printil("public void doTag() throws javax.servlet.jsp.JspException, java.io.IOException {");
+        printilThreePart(out, "public void doTag() throws ", "javax.servlet.jsp.JspException", ", java.io.IOException {");
 
         if (ctxt.isPrototypeMode()) {
             out.printil("}");
@@ -3687,21 +3688,21 @@ class Generator {
          * implicit object in tag files. Declare _jspx_page_context, so we can
          * share the code generator with JSPs.
          */
-        out.printil("javax.servlet.jsp.PageContext _jspx_page_context = (javax.servlet.jsp.PageContext)jspContext;");
+        printilMultiPart(out, "javax.servlet.jsp.PageContext", " _jspx_page_context = (", "javax.servlet.jsp.PageContext", ")jspContext;");
 
         // Declare implicit objects.
-        out.printil("javax.servlet.http.HttpServletRequest request = "
-                + "(javax.servlet.http.HttpServletRequest) _jspx_page_context.getRequest();");
-        out.printil("javax.servlet.http.HttpServletResponse response = "
-                + "(javax.servlet.http.HttpServletResponse) _jspx_page_context.getResponse();");
-        out.printil("javax.servlet.http.HttpSession session = _jspx_page_context.getSession();");
-        out.printil("javax.servlet.ServletContext application = _jspx_page_context.getServletContext();");
-        out.printil("javax.servlet.ServletConfig config = _jspx_page_context.getServletConfig();");
-        out.printil("javax.servlet.jsp.JspWriter out = jspContext.getOut();");
+        printilMultiPart(out, "javax.servlet.http.HttpServletRequest", " request = ",
+                "(", "javax.servlet.http.HttpServletRequest", ") _jspx_page_context.getRequest();");
+        printilMultiPart(out, "javax.servlet.http.HttpServletResponse", " response = ",
+                "(", "javax.servlet.http.HttpServletResponse", ") _jspx_page_context.getResponse();");
+        printilTwoPart(out, "javax.servlet.http.HttpSession", " session = _jspx_page_context.getSession();");
+        printilTwoPart(out, "javax.servlet.ServletContext", " application = _jspx_page_context.getServletContext();");
+        printilTwoPart(out, "javax.servlet.ServletConfig", " config = _jspx_page_context.getServletConfig();");
+        printilTwoPart(out, "javax.servlet.jsp.JspWriter", " out = jspContext.getOut();");
         out.printil("_jspInit(config);");
 
         // set current JspContext on ELContext
-        out.printil("jspContext.getELContext().putContext(javax.servlet.jsp.JspContext.class,jspContext);");
+        printilThreePart(out, "jspContext.getELContext().putContext(", "javax.servlet.jsp.JspContext", ".class,jspContext);");
 
         generatePageScopedVariables(tagInfo);
 
@@ -3719,15 +3720,15 @@ class Generator {
         // helper method is declared to throw Throwable.
         out.printil("} catch( java.lang.Throwable t ) {");
         out.pushIndent();
-        out.printil("if( t instanceof javax.servlet.jsp.SkipPageException )");
-        out.printil("    throw (javax.servlet.jsp.SkipPageException) t;");
+        printilThreePart(out, "if( t instanceof ", "javax.servlet.jsp.SkipPageException", " )");
+        printilThreePart(out, "    throw (", "javax.servlet.jsp.SkipPageException", ") t;");
         out.printil("if( t instanceof java.io.IOException )");
         out.printil("    throw (java.io.IOException) t;");
         out.printil("if( t instanceof java.lang.IllegalStateException )");
         out.printil("    throw (java.lang.IllegalStateException) t;");
-        out.printil("if( t instanceof javax.servlet.jsp.JspException )");
-        out.printil("    throw (javax.servlet.jsp.JspException) t;");
-        out.printil("throw new javax.servlet.jsp.JspException(t);");
+        printilThreePart(out, "if( t instanceof ", "javax.servlet.jsp.JspException", " )");
+        printilThreePart(out, "    throw (", "javax.servlet.jsp.JspException", ") t;");
+        printilThreePart(out, "throw new ", "javax.servlet.jsp.JspException", "(t);");
         out.popIndent();
         out.printil("} finally {");
         out.pushIndent();
@@ -3745,7 +3746,7 @@ class Generator {
         }
 
         // restore nested JspContext on ELContext
-        out.printil("jspContext.getELContext().putContext(javax.servlet.jsp.JspContext.class,super.getJspContext());");
+        printilThreePart(out, "jspContext.getELContext().putContext(", "javax.servlet.jsp.JspContext", ".class,super.getJspContext());");
 
         out.printil("((org.apache.jasper.runtime.JspContextWrapper) jspContext).syncEndTagFile();");
         if (isPoolingEnabled && !tagHandlerPoolNames.isEmpty()) {
@@ -3777,7 +3778,8 @@ class Generator {
         for (int i = 0; i < attrInfos.length; i++) {
             out.printin("private ");
             if (attrInfos[i].isFragment()) {
-                out.print("javax.servlet.jsp.tagext.JspFragment ");
+                out.print("javax.servlet.jsp.tagext.JspFragment");
+                out.print(" ");
             } else {
                 out.print(JspUtil.toJavaSourceType(attrInfos[i].getTypeName()));
                 out.print(" ");
@@ -3796,7 +3798,8 @@ class Generator {
                 // getter method
                 out.printin("public ");
                 if (attrInfos[i].isFragment()) {
-                    out.print("javax.servlet.jsp.tagext.JspFragment ");
+                    out.print("javax.servlet.jsp.tagext.JspFragment");
+                    out.print(" ");
                 } else {
                 out.print(JspUtil.toJavaSourceType(attrInfos[i].getTypeName()));
                     out.print(" ");
@@ -3815,7 +3818,8 @@ class Generator {
                 out.printin("public void ");
                 out.print(toSetterMethodName(attrInfos[i].getName()));
                 if (attrInfos[i].isFragment()) {
-                    out.print("(javax.servlet.jsp.tagext.JspFragment ");
+                    out.print("(javax.servlet.jsp.tagext.JspFragment");
+                    out.print(" ");
                 } else {
                     out.print("(");
                 out.print(JspUtil.toJavaSourceType(attrInfos[i].getTypeName()));
@@ -3867,9 +3871,9 @@ class Generator {
         }
 
         if (aliasSeen) {
-            out.printil("public void setJspContext(javax.servlet.jsp.JspContext ctx, java.util.Map aliasMap) {");
+            printilThreePart(out, "public void setJspContext(", "javax.servlet.jsp.JspContext", " ctx, java.util.Map aliasMap) {");
         } else {
-            out.printil("public void setJspContext(javax.servlet.jsp.JspContext ctx) {");
+            printilThreePart(out, "public void setJspContext(", "javax.servlet.jsp.JspContext", " ctx) {");
         }
         out.pushIndent();
         out.printil("super.setJspContext(ctx);");
@@ -3916,7 +3920,7 @@ class Generator {
         out.popIndent();
         out.printil("}");
         out.println();
-        out.printil("public javax.servlet.jsp.JspContext getJspContext() {");
+        printilThreePart(out, "public ", "javax.servlet.jsp.JspContext", " getJspContext() {");
         out.pushIndent();
         out.printil("return this.jspContext;");
         out.popIndent();
@@ -3930,7 +3934,7 @@ class Generator {
      * variable can later be created for it.
      */
     public void generateSetDynamicAttribute() {
-        out.printil("public void setDynamicAttribute(java.lang.String uri, java.lang.String localName, java.lang.Object value) throws javax.servlet.jsp.JspException {");
+        printilThreePart(out, "public void setDynamicAttribute(java.lang.String uri, java.lang.String localName, java.lang.Object value) throws ", "javax.servlet.jsp.JspException", " {");
         out.pushIndent();
         /*
          * According to the spec, only dynamic attributes with no uri are to be
@@ -3963,11 +3967,11 @@ class Generator {
 
                 // we need to scope the modified VariableMapper for consistency and performance
                 if (!variableMapperVar) {
-                    out.printil("javax.el.VariableMapper _el_variablemapper = jspContext.getELContext().getVariableMapper();");
+                    printilTwoPart(out, "javax.el.VariableMapper", " _el_variablemapper = jspContext.getELContext().getVariableMapper();");
                     variableMapperVar = true;
                 }
 
-                out.printin("javax.el.ValueExpression _el_ve");
+                printinTwoPart(out, "javax.el.ValueExpression", " _el_ve");
                 out.print(i);
                 out.print(" = _el_variablemapper.setVariable(");
                 out.print(quote(attrName));
@@ -3976,7 +3980,7 @@ class Generator {
                     out.print(VAR_EXPRESSIONFACTORY);
                     out.print(".createValueExpression(");
                     out.print(toGetterMethod(attrName));
-                    out.print(",javax.el.MethodExpression.class)");
+                    printThreePart(out, ",", "javax.el.MethodExpression", ".class)");
                 } else {
                     out.print(toGetterMethod(attrName));
                 }
@@ -4236,13 +4240,13 @@ class Generator {
                     + "org.apache.jasper.runtime.JspFragmentHelper");
             out.printil("{");
             out.pushIndent();
-            out.printil("private javax.servlet.jsp.tagext.JspTag _jspx_parent;");
+            printilThreePart(out, "private ", "javax.servlet.jsp.tagext.JspTag", " _jspx_parent;");
             out.printil("private int[] _jspx_push_body_count;");
             out.println();
-            out.printil("public " + className
-                    + "( int discriminator, javax.servlet.jsp.JspContext jspContext, "
-                    + "javax.servlet.jsp.tagext.JspTag _jspx_parent, "
-                    + "int[] _jspx_push_body_count ) {");
+            printilMultiPart(out, "public ", className
+                    , "( int discriminator, ", "javax.servlet.jsp.JspContext", " jspContext, "
+                    , "javax.servlet.jsp.tagext.JspTag", " _jspx_parent, "
+                    , "int[] _jspx_push_body_count ) {");
             out.pushIndent();
             out.printil("super( discriminator, jspContext, _jspx_parent );");
             out.printil("this._jspx_parent = _jspx_parent;");
@@ -4272,7 +4276,7 @@ class Generator {
             } else {
                 out.printin("public void invoke");
             }
-            out.println(result.getId() + "( " + "javax.servlet.jsp.JspWriter out ) ");
+            printlnMultiPart(out, result.getId() + "( ", "javax.servlet.jsp.JspWriter", " out ) ");
             out.pushIndent();
             // Note: Throwable required because methods like _jspx_meth_*
             // throw Throwable.
@@ -4309,11 +4313,11 @@ class Generator {
             // Generate postamble:
             out.printil("public void invoke( java.io.Writer writer )");
             out.pushIndent();
-            out.printil("throws javax.servlet.jsp.JspException");
+            printilTwoPart(out, "throws ", "javax.servlet.jsp.JspException");
             out.popIndent();
             out.printil("{");
             out.pushIndent();
-            out.printil("javax.servlet.jsp.JspWriter out = null;");
+            printilTwoPart(out, "javax.servlet.jsp.JspWriter", " out = null;");
             out.printil("if( writer != null ) {");
             out.pushIndent();
             out.printil("out = this.jspContext.pushBody(writer);");
@@ -4325,8 +4329,8 @@ class Generator {
             out.printil("}");
             out.printil("try {");
             out.pushIndent();
-            out.printil("Object _jspx_saved_JspContext = this.jspContext.getELContext().getContext(javax.servlet.jsp.JspContext.class);");
-            out.printil("this.jspContext.getELContext().putContext(javax.servlet.jsp.JspContext.class,this.jspContext);");
+            printilThreePart(out, "Object _jspx_saved_JspContext = this.jspContext.getELContext().getContext(", "javax.servlet.jsp.JspContext", ".class);");
+            printilThreePart(out, "this.jspContext.getELContext().putContext(", "javax.servlet.jsp.JspContext", ".class,this.jspContext);");
             out.printil("switch( this.discriminator ) {");
             out.pushIndent();
             for (int i = 0; i < fragments.size(); i++) {
@@ -4340,15 +4344,15 @@ class Generator {
             out.printil("}"); // switch
 
             // restore nested JspContext on ELContext
-            out.printil("jspContext.getELContext().putContext(javax.servlet.jsp.JspContext.class,_jspx_saved_JspContext);");
+            printilThreePart(out, "jspContext.getELContext().putContext(", "javax.servlet.jsp.JspContext", ".class,_jspx_saved_JspContext);");
 
             out.popIndent();
             out.printil("}"); // try
             out.printil("catch( java.lang.Throwable e ) {");
             out.pushIndent();
-            out.printil("if (e instanceof javax.servlet.jsp.SkipPageException)");
-            out.printil("    throw (javax.servlet.jsp.SkipPageException) e;");
-            out.printil("throw new javax.servlet.jsp.JspException( e );");
+            printilThreePart(out, "if (e instanceof ", "javax.servlet.jsp.SkipPageException", ")");
+            printilThreePart(out, "    throw (", "javax.servlet.jsp.SkipPageException", ") e;");
+            printilThreePart(out, "throw new ", "javax.servlet.jsp.JspException", "( e );");
             out.popIndent();
             out.printil("}"); // catch
             out.printil("finally {");
@@ -4381,4 +4385,66 @@ class Generator {
             }
         }
     }
+
+    private static void printilTwoPart(ServletWriter out, String one, String two) {
+        out.printin(one);
+        out.println(two);
+    }
+
+    private static void printinTwoPart(ServletWriter out, String one, String two) {
+        out.printin(one);
+        out.print(two);
+    }
+
+    private static void printThreePart(ServletWriter out, String one, String two, String three) {
+        out.print(one);
+        out.print(two);
+        out.print(three);
+    }
+
+    private static void printilThreePart(ServletWriter out, String one, String two, String three) {
+        out.printin(one);
+        out.print(two);
+        out.println(three);
+    }
+
+    private static void printinThreePart(ServletWriter out, String one, String two, String three) {
+        out.printin(one);
+        out.print(two);
+        out.print(three);
+    }
+
+    private static void printlnThreePart(ServletWriter out, String one, String two, String three) {
+        out.print(one);
+        out.print(two);
+        out.println(three);
+    }
+
+    private static void printilMultiPart(ServletWriter out, String... parts) {
+        printMultiPart(out, true, true, parts);
+    }
+
+    private static void printinMultiPart(ServletWriter out, String... parts) {
+        printMultiPart(out, true, false, parts);
+    }
+
+    private static void printlnMultiPart(ServletWriter out, String... parts) {
+        printMultiPart(out, false, true, parts);
+    }
+
+    private static void printMultiPart(ServletWriter out, boolean indent, boolean newLine, String... parts) {
+        assert parts.length > 1;
+        int last = parts.length - 1;
+        for (int i = 0; i <= last; i++) {
+            if (indent && i == 0) {
+                out.printin(parts[i]);
+            } else if (newLine && i == last) {
+                out.println(parts[i]);
+            } else {
+                out.print(parts[i]);
+            }
+        }
+    }
+
+
 }


### PR DESCRIPTION
…mation

https://issues.redhat.com/browse/UNDERTOW-1768

Optimize jastow constants for javax->jakarta transformation

@fl4via This is basically about using distinct constant strings for any classnames in the javax.* namespace, such that bytecode transformation can easily match them against its transformation ruleset, which uses an exact string match for these.

See https://github.com/eclipse/transformer/issues/79 for some background.

If Eclipse Transformer adds support for some kind of regex matching, probably this could be reverted.

The approach here is fairly heavy as I wanted to avoid any reliance on static string concatenation using the + operator as I don't want to rely on the compiler not combining the strings. (I actually have a branch that does this using constants for the package names and string concat.)

If this makes sense I'll send up a PR for master.