### PR TITLE
Fix compilation of JSPs with nested classes after ECJ update

### DIFF
--- a/src/main/java/org/apache/jasper/compiler/JDTCompiler.java
+++ b/src/main/java/org/apache/jasper/compiler/JDTCompiler.java
@@ -222,7 +222,7 @@ public class JDTCompiler extends org.apache.jasper.compiler.Compiler {
                 }
 
                 private boolean isPackage(String result) {
-                    if (result.equals(targetClassName)) {
+                    if (result.equals(targetClassName) || result.startsWith(targetClassName + '$')) {
                         return false;
                     }
                     String packageName = result.replace('.', '/');

--- a/src/test/java/io/undertow/test/jsp/basic/SimpleJspTestCase.java
+++ b/src/test/java/io/undertow/test/jsp/basic/SimpleJspTestCase.java
@@ -39,6 +39,8 @@ import org.apache.http.util.EntityUtils;
 import org.apache.jasper.deploy.JspPropertyGroup;
 import org.apache.jasper.deploy.TagLibraryInfo;
 import org.apache.jasper.servlet.JspServlet;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -141,6 +143,20 @@ public class SimpleJspTestCase {
             // we expect the return code to be 405
             Assert.assertEquals("Unexpected response code from " + httpPut.getMethod() + " request to a JSP", 405, putResponse.getStatusLine().getStatusCode());
 
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
+    @Test
+    public void testInnerClassesJsp() throws IOException {
+        TestHttpClient client = new TestHttpClient();
+        try {
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL() + "/servletContext/inner-classes.jsp");
+            HttpResponse result = client.execute(get);
+            Assert.assertEquals(200, result.getStatusLine().getStatusCode());
+            final String response = HttpClientUtils.readResponse(result);
+            MatcherAssert.assertThat(response, CoreMatchers.containsString("555-2368<br/>"));
         } finally {
             client.getConnectionManager().shutdown();
         }

--- a/src/test/java/io/undertow/test/jsp/basic/inner-classes.jsp
+++ b/src/test/java/io/undertow/test/jsp/basic/inner-classes.jsp
@@ -1,0 +1,55 @@
+<%@page import="java.util.*"%>
+
+<%
+class PhoneBean {
+    private String area;
+    private String number;
+
+    public PhoneBean(String area, String number) {
+        this.area = area;
+        this.number = number;
+    }
+
+    public String getArea() {
+        return area;
+    }
+
+    public String getNumber() {
+        return number;
+    }
+}
+
+class EmployeeBean {
+    private String id;
+    private List<PhoneBean> phoneBeans = new ArrayList<>();
+
+    String getId() {
+        return id;
+    }
+
+    void setId(String id) {
+        this.id = id;
+    }
+
+    List<PhoneBean> getPhoneBeans() {
+        return phoneBeans;
+    }
+}
+%>
+
+<%
+    EmployeeBean bean = new EmployeeBean();
+    bean.setId("1");
+    bean.getPhoneBeans().add(new PhoneBean("555", "2368"));
+%>
+<html>
+    <head>
+        <title>Inner classes test</title>
+    </head>
+
+    <body>
+        <% for (PhoneBean phoneBean: bean.getPhoneBeans()) { %>
+        <%= phoneBean.getArea() %>-<%= phoneBean.getNumber() %><br/>
+        <% } %>
+    </table>
+</body>


### PR DESCRIPTION
Fix for [UNDERTOW-2104](https://issues.redhat.com/browse/UNDERTOW-2104) - for master branch.

After upgrade of ECJ version Jastow is unable to properly compile some JSPs with local classes (i.e. nested classes defined in scriplet) - ECJ now issues additional call 'isPackage' for such classes and existing implementation in JDTCompiler class doesn't work with nested classes.