### PR TITLE
[UNDERTOW-2214] Jastow compilation error when mixing EL and scriptlet expressions after UNDERTOW-1319

### DIFF
--- a/src/main/java/org/apache/jasper/compiler/Validator.java
+++ b/src/main/java/org/apache/jasper/compiler/Validator.java
@@ -1337,11 +1337,6 @@ class Validator {
                     result = new Node.JspAttribute(tai, qName, uri, localName,
                             value.substring(3, value.length() - 2), true, null,
                             dynamic);
-                }else if(!n.getRoot().isXmlSyntax()
-                        && value.contains("<%=") && value.contains("%>") && (value.indexOf("<%=") < value.indexOf("%>"))) {
-                    result = new Node.JspAttribute(tai, qName, uri, localName,
-                            partialScriptletExpression(value), true, null,
-                            dynamic);
                 } else {
                     if (!pageInfo.isELIgnored()) {
                     // The attribute can contain expressions but is not a
@@ -1420,16 +1415,6 @@ class Validator {
             }
 
             return result;
-        }
-
-        // [UNDERTOW-1319]
-        private String partialScriptletExpression(String url) {
-            String result = "\"" + url.replaceAll("<%=", "\"+").replaceAll("%>", "+\"");
-            if (result.lastIndexOf("+\"") == result.length() - 2) {
-                return result.substring(0, result.length() - 2);
-            } else {
-                return result + "\"";
-            }
         }
 
 

--- a/src/test/java/io/undertow/test/jsp/taglib/MyOutTag.java
+++ b/src/test/java/io/undertow/test/jsp/taglib/MyOutTag.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.undertow.test.jsp.taglib;
+
+import java.io.IOException;
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.tagext.SimpleTagSupport;
+
+/**
+ *
+ * @author rmartinc
+ */
+public class MyOutTag extends SimpleTagSupport {
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public void doTag() throws JspException, IOException {
+        getJspContext().getOut().print(value);
+    }
+}

--- a/src/test/java/io/undertow/test/jsp/taglib/bug.tld
+++ b/src/test/java/io/undertow/test/jsp/taglib/bug.tld
@@ -16,4 +16,15 @@
     <function-signature>java.lang.Runtime getRuntime()</function-signature>
   </function>
 
+  <tag>
+    <name>out</name>
+    <tag-class>io.undertow.test.jsp.taglib.MyOutTag</tag-class>
+    <body-content>empty</body-content>
+    <attribute>
+      <name>value</name>
+      <required>true</required>
+      <rtexprvalue>true</rtexprvalue>
+    </attribute>
+  </tag>
+
 </taglib>

--- a/src/test/java/io/undertow/test/jsp/taglib/scriptlet-expression.jsp
+++ b/src/test/java/io/undertow/test/jsp/taglib/scriptlet-expression.jsp
@@ -1,0 +1,33 @@
+<%--
+    JBoss, Home of Professional Open Source.
+    Copyright 2012 Red Hat, Inc., and individual contributors
+    as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+--%>
+<%@ taglib uri="/bug.tld" prefix="bug" %>
+<html>
+    <head>
+        <title>Scriptlet expression test</title>
+    </head>
+
+    <body>
+        <ul>
+            <li>Line1|<bug:out value="<%= \"interpreted \" + Boolean.TRUE %>"/>|Line1</li>
+            <li>Line2|<bug:out value="not interpreted <%= Boolean.TRUE %>"/>|Line2</li>
+            <li>Line3|<bug:out value="not interpreted ${Boolean.TRUE} <%= Boolean.TRUE %>"/>|Line3</li>
+            <li>Line4|<bug:out value="\"function(<%= Boolean.TRUE %>, ${Boolean.TRUE}})\""/>|Line4</li>
+            <li>Line5|<bug:out value="interpreted ${Boolean.TRUE} ${Boolean.TRUE}"/>|Line5</li>
+        </ul>
+    </table>
+</body>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/UNDERTOW-2214

Reverting UNDERTOW-1319 to be compliant with the spec. In a JSP tag attribute a value scriptlet expression must appear by itself (full attribute), multiple expressions, and mixing of expressions and string constants are not permitted. Adding a simple test in the ` TagLibJspTestCase` to ensure the behavior is not changed again.

If anybody prefers an intermediate solution (for example accepting the previous bad behavior by default or after setting a system property) just let me now. But I prefer to be spec compliant and do not complicate the validation (as the previous fix was incomplete).

PR for 2.0.x.
PR for 2.2.x: https://github.com/undertow-io/jastow/pull/77