### PR TITLE
[UNDERTOW-2222] Jastow should use UTF-8 for default URI encoding like Undertow

### DIFF
--- a/src/main/java/org/apache/jasper/compiler/Generator.java
+++ b/src/main/java/org/apache/jasper/compiler/Generator.java
@@ -989,7 +989,7 @@ class Generator {
             if (attr.isExpression()) {
                 if (encode) {
                     return JSP_RUNTIME_LIBRARY + ".URLEncode(String.valueOf("
-                            + v + "), request.getCharacterEncoding())";
+                            + v + "), " + JSP_RUNTIME_LIBRARY + ".getURLCharacterEncoding(request))";
                 }
                 return v;
             } else if (attr.isELInterpreterInput()) {
@@ -997,7 +997,7 @@ class Generator {
                         expectedType, attr.getEL().getMapName());
                 if (encode) {
                     return JSP_RUNTIME_LIBRARY + ".URLEncode("
-                            + v + ", request.getCharacterEncoding())";
+                            + v + ", " + JSP_RUNTIME_LIBRARY + ".getURLCharacterEncoding(request))";
                 }
                 return v;
             } else if (attr.isNamedAttribute()) {
@@ -1005,7 +1005,7 @@ class Generator {
             } else {
                 if (encode) {
                     return JSP_RUNTIME_LIBRARY + ".URLEncode("
-                            + quote(v) + ", request.getCharacterEncoding())";
+                            + quote(v) + ", " + JSP_RUNTIME_LIBRARY + ".getURLCharacterEncoding(request))";
                 }
                 return quote(v);
             }
@@ -1037,7 +1037,7 @@ class Generator {
                     out.print(" + ");
                     out.print(JSP_RUNTIME_LIBRARY
                             + ".URLEncode(" + quote(n.getTextAttribute("name"))
-                            + ", request.getCharacterEncoding())");
+                            + ", " + JSP_RUNTIME_LIBRARY + ".getURLCharacterEncoding(request))");
                     out.print("+ \"=\" + ");
                     out.print(attributeValue(n.getValue(), true, String.class));
 

--- a/src/main/java/org/apache/jasper/runtime/JspRuntimeLibrary.java
+++ b/src/main/java/org/apache/jasper/runtime/JspRuntimeLibrary.java
@@ -19,12 +19,16 @@ package org.apache.jasper.runtime;
 
 import static org.apache.jasper.JasperMessages.MESSAGES;
 
+import io.undertow.UndertowOptions;
+import io.undertow.servlet.spec.HttpServletRequestImpl;
+
 import java.beans.PropertyEditor;
 import java.beans.PropertyEditorManager;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
@@ -33,6 +37,7 @@ import java.util.Enumeration;
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletRequestWrapper;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.jsp.JspWriter;
@@ -983,4 +988,22 @@ public class JspRuntimeLibrary {
 	return false;
     }
 
+    /**
+     * Returns the URL character encoding used in the undertow connection.
+     * If the request is a ServletRequestWrapper it is unwrapped to get the
+     * final undertow implementation.
+     *
+     * @param request The servlet request being processed
+     * @return The URL charset used in undertow, default is UTF-8
+     */
+    public static String getURLCharacterEncoding(ServletRequest request) {
+        while (request instanceof ServletRequestWrapper) {
+            request = ((ServletRequestWrapper) request).getRequest();
+        }
+        if (request instanceof HttpServletRequestImpl) {
+            return ((HttpServletRequestImpl) request).getExchange().getConnection()
+                    .getUndertowOptions().get(UndertowOptions.URL_CHARSET, StandardCharsets.UTF_8.name());
+        }
+        return StandardCharsets.UTF_8.name();
+    }
 }

--- a/src/test/java/io/undertow/test/jsp/basic/SimpleJspTestCase.java
+++ b/src/test/java/io/undertow/test/jsp/basic/SimpleJspTestCase.java
@@ -162,4 +162,18 @@ public class SimpleJspTestCase {
         }
     }
 
+    @Test
+    public void testURLCharacterEncoding() throws IOException {
+        TestHttpClient client = new TestHttpClient();
+        try {
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL() + "/servletContext/include-parent.jsp");
+            HttpResponse result = client.execute(get);
+            Assert.assertEquals(200, result.getStatusLine().getStatusCode());
+            final String response = HttpClientUtils.readResponse(result);
+            MatcherAssert.assertThat(response, CoreMatchers.containsString("euro=€"));
+            MatcherAssert.assertThat(response, CoreMatchers.containsString("acutes=áéíóú"));
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
 }

--- a/src/test/java/io/undertow/test/jsp/basic/include-parent.jsp
+++ b/src/test/java/io/undertow/test/jsp/basic/include-parent.jsp
@@ -1,0 +1,9 @@
+<%@ page language="java" contentType="text/html;charset=UTF-8" pageEncoding="UTF-8"%>
+<html>
+    <body>
+        <jsp:include page="/include.jsp">
+            <jsp:param name="euro" value="€" />
+            <jsp:param name="acutes" value="áéíóú" />
+        </jsp:include>
+    </body>
+</html>

--- a/src/test/java/io/undertow/test/jsp/basic/include.jsp
+++ b/src/test/java/io/undertow/test/jsp/basic/include.jsp
@@ -1,0 +1,5 @@
+<%@ page language="java" contentType="text/html;charset=UTF-8" pageEncoding="UTF-8"%>
+<ul>
+    <li>euro=${param.euro}</li>
+    <li>acutes=${param.acutes}</li>
+</ul>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/UNDERTOW-2222

URL encoding in `Generator.java` is only used for `jsp:forward` and `jsp:include` and therefore the encoding should be retrieved from the URL_CHARSET undertow option (defaulting to `UTF-8`) instead of calling `getCharacterEncoding`. The latter returns the encoding for the request body and not the charset for URL parsing. A utility method is created in `JspRuntimeLibrary.java` to retrieve the undertow option from the connection if available. Test added.

PR for master/2.2.x.
PR for 2.0.x: https://github.com/undertow-io/jastow/pull/80