### PR TITLE
[UNDERTOW-2549] ensure tags aren't reused after exception without reintroducing UNDERTOW-2401 leak

### DIFF
--- a/src/main/java/org/apache/jasper/compiler/Generator.java
+++ b/src/main/java/org/apache/jasper/compiler/Generator.java
@@ -2397,6 +2397,9 @@ class Generator {
                 out.print(".get(");
                 out.print(tagHandlerClassName);
                 out.println(".class);");
+                out.printin("boolean ");
+                out.print(tagHandlerVar);
+                out.println("_reused = false;");
             } else {
                 writeNewInstance(tagHandlerVar, tagHandlerClassName);
             }
@@ -2605,20 +2608,35 @@ class Generator {
                 out.printil("}");
             }
 
-            // Ensure clean-up takes place
-            out.popIndent();
-            out.printil("} finally {");
-            out.pushIndent();
+            // Print tag reuse
             if (isPoolingEnabled && !(n.implementsJspIdConsumer())) {
                 out.printin(n.getTagHandlerPoolName());
                 out.print(".reuse(");
                 out.print(tagHandlerVar);
                 out.println(");");
-            } else {
-                out.printin(tagHandlerVar);
-                out.println(".release();");
-                writeDestroyInstance(tagHandlerVar);
+                out.print(tagHandlerVar);
+                out.println("_reused = true;");
             }
+
+            // Ensure clean-up takes place
+            // Required to prevent UNDERTOW-2401 leaks
+            out.popIndent();
+            out.printil("} finally {");
+            out.pushIndent();
+            if (isPoolingEnabled && !(n.implementsJspIdConsumer())) {
+                out.printin("if (!");
+                out.print(tagHandlerVar);
+                out.println("_reused) {");
+                out.pushIndent();
+            }
+            out.printin(tagHandlerVar);
+            out.println(".release();");
+            writeDestroyInstance(tagHandlerVar);
+            if (isPoolingEnabled && !(n.implementsJspIdConsumer())) {
+                out.popIndent();
+                out.printil("}");
+            }
+
             out.popIndent();
             out.printil("}");
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/UNDERTOW-2549
Upstream: https://github.com/apache/tomcat/commit/18b53513d76def3e49a2c11200eb17acda8a0c5f
https://github.com/apache/tomcat/commit/31d53e13ec5873462ecc42f193d13bd0b446d3b6

2.3.x: https://github.com/undertow-io/jastow/pull/143
2.2.x: https://github.com/undertow-io/jastow/pull/142